### PR TITLE
Phase 6: Media Lifecycle and Storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,15 @@ LLM_MAX_INPUT_CHARS=2000
 ENRICHMENT_ENABLED=true
 OPEN_FOOD_FACTS_BASE_URL=https://world.openfoodfacts.org
 ENRICHMENT_HTTP_TIMEOUT_SECONDS=8
+
+# Phase 6 (Media lifecycle and storage)
+# MEDIA_STORE_MODE:
+# - noop: disable media upload (default)
+# - gcs: upload operator photos/previews to Google Cloud Storage
+MEDIA_STORE_MODE=noop
+MEDIA_GCS_BUCKET=
+MEDIA_GCS_PUBLIC_BASE_URL=https://storage.googleapis.com
+MEDIA_GCS_OBJECT_PREFIX=operator-photos
+MEDIA_LIFECYCLE_DAYS=90
+MEDIA_VERIFY_LIFECYCLE_ON_STARTUP=false
+WHATSAPP_MEDIA_TIMEOUT_SECONDS=15

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@
   - `ENRICHMENT_HTTP_TIMEOUT_SECONDS` (default `8`)
   - provider chain order: Open Food Facts -> EAN fallback -> web-search fallback
   - only normalized enrichment fields are stored in DB; raw provider payloads are not persisted
+- Media lifecycle/storage configuration (Phase 6):
+  - `MEDIA_STORE_MODE` (`noop` or `gcs`, default `noop`)
+  - `MEDIA_GCS_BUCKET` (required when `MEDIA_STORE_MODE=gcs`)
+  - `MEDIA_GCS_PUBLIC_BASE_URL` (default `https://storage.googleapis.com`)
+  - `MEDIA_GCS_OBJECT_PREFIX` (default `operator-photos`)
+  - `MEDIA_LIFECYCLE_DAYS` (default `90`)
+  - `MEDIA_VERIFY_LIFECYCLE_ON_STARTUP` (default `false`; when `true`, app startup validates a matching GCS Delete lifecycle rule)
+  - `WHATSAPP_MEDIA_TIMEOUT_SECONDS` (default `15`)
+  - authorized operator image messages now trigger Meta media download + upload to configured media store and update draft `photo_url`
 
 ## Database Migrations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "psycopg[binary]>=3.2.13,<4.0.0",
   "google-auth>=2.39.0,<3.0.0",
   "google-cloud-tasks>=2.19.3,<3.0.0",
+  "google-cloud-storage>=2.19.0,<3.0.0",
   "openai>=1.75.0,<2.0.0",
 ]
 

--- a/src/adv_assistant/config.py
+++ b/src/adv_assistant/config.py
@@ -47,6 +47,7 @@ class Settings:
     whatsapp_access_token: str | None = None
     whatsapp_phone_number_id: str | None = None
     whatsapp_graph_api_version: str = "v21.0"
+    whatsapp_media_timeout_seconds: int = 15
 
     tasks_mode: str = "inline"
     gcp_project_id: str | None = None
@@ -70,6 +71,13 @@ class Settings:
     open_food_facts_base_url: str = "https://world.openfoodfacts.org"
     enrichment_http_timeout_seconds: int = 8
 
+    media_store_mode: str = "noop"
+    media_gcs_bucket: str | None = None
+    media_gcs_public_base_url: str = "https://storage.googleapis.com"
+    media_gcs_object_prefix: str = "operator-photos"
+    media_lifecycle_days: int = 90
+    media_verify_lifecycle_on_startup: bool = False
+
     @classmethod
     def from_env(cls) -> "Settings":
         return cls(
@@ -88,6 +96,7 @@ class Settings:
             whatsapp_access_token=os.getenv("WHATSAPP_ACCESS_TOKEN"),
             whatsapp_phone_number_id=os.getenv("PHONE_NUMBER_ID"),
             whatsapp_graph_api_version=os.getenv("GRAPH_API_VERSION", "v21.0"),
+            whatsapp_media_timeout_seconds=_int_env("WHATSAPP_MEDIA_TIMEOUT_SECONDS", 15),
             tasks_mode=os.getenv("TASKS_MODE", "inline"),
             gcp_project_id=os.getenv("GCP_PROJECT_ID"),
             tasks_region=os.getenv("TASKS_REGION") or os.getenv("GCP_REGION"),
@@ -109,4 +118,12 @@ class Settings:
                 "OPEN_FOOD_FACTS_BASE_URL", "https://world.openfoodfacts.org"
             ),
             enrichment_http_timeout_seconds=_int_env("ENRICHMENT_HTTP_TIMEOUT_SECONDS", 8),
+            media_store_mode=os.getenv("MEDIA_STORE_MODE", "noop"),
+            media_gcs_bucket=_optional_env("MEDIA_GCS_BUCKET"),
+            media_gcs_public_base_url=os.getenv(
+                "MEDIA_GCS_PUBLIC_BASE_URL", "https://storage.googleapis.com"
+            ),
+            media_gcs_object_prefix=os.getenv("MEDIA_GCS_OBJECT_PREFIX", "operator-photos"),
+            media_lifecycle_days=_int_env("MEDIA_LIFECYCLE_DAYS", 90),
+            media_verify_lifecycle_on_startup=_bool_env("MEDIA_VERIFY_LIFECYCLE_ON_STARTUP", False),
         )

--- a/src/adv_assistant/main.py
+++ b/src/adv_assistant/main.py
@@ -28,6 +28,13 @@ from adv_assistant.ingress import (
     verify_x_hub_signature,
 )
 from adv_assistant.llm_gateway import NoopLLMGateway, OpenAILLMGateway
+from adv_assistant.media_ingest import (
+    DefaultOperatorPhotoIngestor,
+    NoopWhatsAppMediaClient,
+    OperatorPhotoIngestor,
+    WhatsAppMediaClient,
+)
+from adv_assistant.media_store import GCSMediaStore, MediaStore, NoopMediaStore
 from adv_assistant.pipeline import InboundTaskProcessor
 from adv_assistant.tasks_auth import (
     OidcTaskRequestAuthorizer,
@@ -40,7 +47,12 @@ from adv_assistant.tasks_queue import (
     InlineTaskEnqueuer,
     TaskEnqueuer,
 )
-from adv_assistant.whatsapp import MetaWhatsAppClient, NoopWhatsAppClient, WhatsAppClient
+from adv_assistant.whatsapp import (
+    MetaWhatsAppClient,
+    MetaWhatsAppMediaClient,
+    NoopWhatsAppClient,
+    WhatsAppClient,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +89,43 @@ def _build_enrichment_service(settings: Settings) -> ProviderChainEnrichmentServ
             NoopProductLookupProvider("ean_fallback"),
             NoopProductLookupProvider("web_search"),
         ]
+    )
+
+
+def _build_media_store(settings: Settings) -> MediaStore:
+    mode = settings.media_store_mode.strip().lower()
+    if mode == "noop":
+        return NoopMediaStore()
+    if mode == "gcs":
+        if not settings.media_gcs_bucket:
+            raise RuntimeError("MEDIA_GCS_BUCKET is required when MEDIA_STORE_MODE=gcs")
+        return GCSMediaStore(
+            bucket_name=settings.media_gcs_bucket,
+            project_id=settings.gcp_project_id,
+            public_base_url=settings.media_gcs_public_base_url,
+            object_prefix=settings.media_gcs_object_prefix,
+        )
+    raise RuntimeError(f"Unsupported MEDIA_STORE_MODE='{settings.media_store_mode}'")
+
+
+def _build_whatsapp_media_client(settings: Settings) -> WhatsAppMediaClient:
+    if settings.whatsapp_access_token:
+        return MetaWhatsAppMediaClient(
+            access_token=settings.whatsapp_access_token,
+            graph_api_version=settings.whatsapp_graph_api_version,
+            timeout_seconds=settings.whatsapp_media_timeout_seconds,
+        )
+    return NoopWhatsAppMediaClient()
+
+
+def _build_operator_photo_ingestor(
+    *,
+    media_store: MediaStore,
+    whatsapp_media_client: WhatsAppMediaClient,
+) -> OperatorPhotoIngestor:
+    return DefaultOperatorPhotoIngestor(
+        media_client=whatsapp_media_client,
+        media_store=media_store,
     )
 
 
@@ -166,6 +215,23 @@ def _inspect_schema(sync_connection) -> tuple[set[str], set[str]]:
     return table_names, ad_draft_columns
 
 
+async def _validate_media_lifecycle(
+    *,
+    settings: Settings,
+    media_store: MediaStore,
+) -> None:
+    if not settings.media_verify_lifecycle_on_startup:
+        return
+    if settings.media_store_mode.strip().lower() != "gcs":
+        return
+    has_rule = await media_store.has_delete_lifecycle_rule(days=settings.media_lifecycle_days)
+    if not has_rule:
+        raise RuntimeError(
+            "GCS lifecycle policy mismatch: expected a Delete rule with age="
+            f"{settings.media_lifecycle_days} days on bucket '{settings.media_gcs_bucket}'."
+        )
+
+
 def create_app(settings: Settings | None = None) -> FastAPI:
     current_settings = settings or Settings.from_env()
 
@@ -186,11 +252,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         llm_gateway = NoopLLMGateway()
 
     whatsapp_client = _build_whatsapp_client(current_settings)
+    whatsapp_media_client = _build_whatsapp_media_client(current_settings)
     enrichment_service = _build_enrichment_service(current_settings)
+    media_store = _build_media_store(current_settings)
+    operator_photo_ingestor = _build_operator_photo_ingestor(
+        media_store=media_store,
+        whatsapp_media_client=whatsapp_media_client,
+    )
     task_processor = InboundTaskProcessor(
         session_factory,
         llm_gateway=llm_gateway,
         enrichment_service=enrichment_service,
+        operator_photo_ingestor=operator_photo_ingestor,
     )
 
     async def process_and_maybe_send_reply(payload: InboundTaskPayload):
@@ -245,10 +318,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         try:
             await _validate_schema_compatibility(engine=engine, settings=current_settings)
+            await _validate_media_lifecycle(settings=current_settings, media_store=media_store)
             yield
         finally:
+            await operator_photo_ingestor.close()
             await whatsapp_client.close()
+            await whatsapp_media_client.close()
             await enrichment_service.close()
+            await media_store.close()
             await engine.dispose()
 
     app = FastAPI(title=current_settings.app_name, lifespan=lifespan)
@@ -260,6 +337,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.state.task_enqueuer = task_enqueuer
     app.state.task_authorizer = task_authorizer
     app.state.whatsapp_client = whatsapp_client
+    app.state.whatsapp_media_client = whatsapp_media_client
+    app.state.media_store = media_store
     app.state.process_and_maybe_send_reply = process_and_maybe_send_reply
 
     def get_settings() -> Settings:

--- a/src/adv_assistant/media_ingest.py
+++ b/src/adv_assistant/media_ingest.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from adv_assistant.media_store import MediaStore, MediaStoreError
+
+
+class MediaIngestError(RuntimeError):
+    """Raised when inbound operator media ingest fails."""
+
+
+@dataclass(slots=True)
+class DownloadedMedia:
+    content: bytes
+    content_type: str
+
+
+@dataclass(slots=True)
+class IngestedOperatorPhoto:
+    public_url: str
+    object_name: str
+    content_type: str
+    content: bytes
+
+
+class WhatsAppMediaClient(Protocol):
+    async def download_media(self, *, media_id: str) -> DownloadedMedia: ...
+
+    async def close(self) -> None: ...
+
+
+class OperatorPhotoIngestor(Protocol):
+    async def ingest_whatsapp_image(self, *, media_id: str) -> IngestedOperatorPhoto: ...
+
+    async def close(self) -> None: ...
+
+
+class NoopWhatsAppMediaClient:
+    async def download_media(self, *, media_id: str) -> DownloadedMedia:
+        raise MediaIngestError("WhatsApp media client is not configured")
+
+    async def close(self) -> None:
+        return None
+
+
+class NoopOperatorPhotoIngestor:
+    async def ingest_whatsapp_image(self, *, media_id: str) -> IngestedOperatorPhoto:
+        raise MediaIngestError("Operator photo ingest is not configured")
+
+    async def close(self) -> None:
+        return None
+
+
+class DefaultOperatorPhotoIngestor:
+    def __init__(
+        self,
+        *,
+        media_client: WhatsAppMediaClient,
+        media_store: MediaStore,
+    ) -> None:
+        self._media_client = media_client
+        self._media_store = media_store
+
+    async def ingest_whatsapp_image(self, *, media_id: str) -> IngestedOperatorPhoto:
+        if not media_id.strip():
+            raise MediaIngestError("media_id is required")
+
+        downloaded = await self._media_client.download_media(media_id=media_id)
+        if not downloaded.content:
+            raise MediaIngestError("Downloaded media payload is empty")
+        if not downloaded.content_type.startswith("image/"):
+            raise MediaIngestError(
+                f"Unsupported media type '{downloaded.content_type}', expected image/*"
+            )
+
+        suffix = _extension_for_content_type(downloaded.content_type)
+        try:
+            upload = await self._media_store.upload_bytes(
+                content=downloaded.content,
+                content_type=downloaded.content_type,
+                suffix=suffix,
+            )
+        except MediaStoreError as exc:
+            raise MediaIngestError(str(exc)) from exc
+
+        return IngestedOperatorPhoto(
+            public_url=upload.public_url,
+            object_name=upload.object_name,
+            content_type=downloaded.content_type,
+            content=downloaded.content,
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def _extension_for_content_type(content_type: str) -> str:
+    normalized = content_type.strip().lower().split(";")[0]
+    mapping = {
+        "image/jpeg": ".jpg",
+        "image/jpg": ".jpg",
+        "image/png": ".png",
+        "image/webp": ".webp",
+        "image/heic": ".heic",
+        "image/heif": ".heif",
+        "image/gif": ".gif",
+    }
+    return mapping.get(normalized, "")

--- a/src/adv_assistant/media_store.py
+++ b/src/adv_assistant/media_store.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.parse import quote
+
+from google.cloud import storage
+
+
+class MediaStoreError(RuntimeError):
+    """Raised when media storage operations fail."""
+
+
+@dataclass(slots=True)
+class MediaUpload:
+    object_name: str
+    public_url: str
+
+
+class MediaStore(Protocol):
+    async def upload_bytes(
+        self,
+        *,
+        content: bytes,
+        content_type: str,
+        object_name: str | None = None,
+        suffix: str | None = None,
+    ) -> MediaUpload: ...
+
+    async def has_delete_lifecycle_rule(self, *, days: int) -> bool: ...
+
+    async def close(self) -> None: ...
+
+
+class NoopMediaStore:
+    async def upload_bytes(
+        self,
+        *,
+        content: bytes,
+        content_type: str,
+        object_name: str | None = None,
+        suffix: str | None = None,
+    ) -> MediaUpload:
+        raise MediaStoreError("Media store is not configured")
+
+    async def has_delete_lifecycle_rule(self, *, days: int) -> bool:
+        return False
+
+    async def close(self) -> None:
+        return None
+
+
+class GCSMediaStore:
+    def __init__(
+        self,
+        *,
+        bucket_name: str,
+        project_id: str | None = None,
+        public_base_url: str = "https://storage.googleapis.com",
+        object_prefix: str = "operator-photos",
+        client: storage.Client | None = None,
+    ) -> None:
+        if not bucket_name.strip():
+            raise ValueError("bucket_name is required")
+
+        self._bucket_name = bucket_name.strip()
+        self._project_id = project_id
+        self._public_base_url = public_base_url.rstrip("/")
+        self._object_prefix = object_prefix.strip().strip("/")
+        self._client = client or storage.Client(project=project_id)
+
+    async def upload_bytes(
+        self,
+        *,
+        content: bytes,
+        content_type: str,
+        object_name: str | None = None,
+        suffix: str | None = None,
+    ) -> MediaUpload:
+        resolved_object_name = object_name or self._build_object_name(suffix=suffix)
+        await asyncio.to_thread(
+            self._upload_sync,
+            resolved_object_name,
+            content,
+            content_type,
+        )
+        return MediaUpload(
+            object_name=resolved_object_name,
+            public_url=self._build_public_url(resolved_object_name),
+        )
+
+    async def has_delete_lifecycle_rule(self, *, days: int) -> bool:
+        return await asyncio.to_thread(self._has_delete_lifecycle_rule_sync, days)
+
+    async def close(self) -> None:
+        return None
+
+    def _build_object_name(self, *, suffix: str | None) -> str:
+        extension = (suffix or "").strip().lower()
+        generated = f"{uuid.uuid4()}{extension}"
+        if self._object_prefix:
+            return f"{self._object_prefix}/{generated}"
+        return generated
+
+    def _build_public_url(self, object_name: str) -> str:
+        escaped = quote(object_name, safe="/")
+        return f"{self._public_base_url}/{self._bucket_name}/{escaped}"
+
+    def _upload_sync(self, object_name: str, content: bytes, content_type: str) -> None:
+        bucket = self._client.bucket(self._bucket_name)
+        blob = bucket.blob(object_name)
+        blob.upload_from_string(content, content_type=content_type)
+
+    def _has_delete_lifecycle_rule_sync(self, days: int) -> bool:
+        bucket = self._client.bucket(self._bucket_name)
+        bucket.reload()
+        rules = bucket.lifecycle_rules or []
+        for rule in rules:
+            action = (rule.get("action", {}) or {}).get("type")
+            condition = rule.get("condition", {}) or {}
+            age = condition.get("age")
+            if str(action).lower() == "delete" and age == days:
+                return True
+        return False

--- a/src/adv_assistant/pipeline.py
+++ b/src/adv_assistant/pipeline.py
@@ -33,6 +33,11 @@ from adv_assistant.llm_gateway import (
     extract_button_payload_id,
     sanitize_user_text,
 )
+from adv_assistant.media_ingest import (
+    MediaIngestError,
+    NoopOperatorPhotoIngestor,
+    OperatorPhotoIngestor,
+)
 from adv_assistant.tasks_queue import InboundTaskPayload
 
 
@@ -67,6 +72,19 @@ def _extract_text(raw_message: dict[str, Any]) -> str | None:
     return stripped or None
 
 
+def _extract_image_media_id(raw_message: dict[str, Any]) -> str | None:
+    if raw_message.get("type") != "image":
+        return None
+    image_payload = raw_message.get("image")
+    if not isinstance(image_payload, dict):
+        return None
+    media_id = image_payload.get("id")
+    if not isinstance(media_id, str):
+        return None
+    stripped = media_id.strip()
+    return stripped or None
+
+
 class InboundTaskProcessor:
     def __init__(
         self,
@@ -74,10 +92,12 @@ class InboundTaskProcessor:
         *,
         llm_gateway: LLMGateway | None = None,
         enrichment_service: EnrichmentService | None = None,
+        operator_photo_ingestor: OperatorPhotoIngestor | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._llm_gateway = llm_gateway or NoopLLMGateway()
         self._enrichment_service = enrichment_service or NoopEnrichmentService()
+        self._operator_photo_ingestor = operator_photo_ingestor or NoopOperatorPhotoIngestor()
 
     async def process(self, payload: InboundTaskPayload) -> ProcessInboundResult:
         async with session_scope(self._session_factory) as session:
@@ -142,6 +162,7 @@ class InboundTaskProcessor:
                 raise RuntimeError("current draft was not created")
 
             incoming_text = _extract_text(payload.raw_message)
+            incoming_image_media_id = _extract_image_media_id(payload.raw_message)
             button_payload_id = extract_button_payload_id(payload.raw_message)
             llm_used = False
             intent_value: str | None = None
@@ -163,6 +184,24 @@ class InboundTaskProcessor:
                     action="button_callback_resolved",
                     operator_phone=payload.operator_phone,
                     metadata={"wamid": payload.wamid, "button_id": button_payload_id},
+                )
+            elif incoming_image_media_id is not None:
+                history.append(
+                    {
+                        "role": "user",
+                        "text": "[image]",
+                        "wamid": payload.wamid,
+                    }
+                )
+                deterministic_action = "operator_photo_ingest"
+                intent_value = deterministic_action
+                current_draft, reply_text = await self._process_operator_photo_message(
+                    payload=payload,
+                    draft_repo=draft_repo,
+                    audit_repo=audit_repo,
+                    current_draft=current_draft,
+                    language=operator.language,
+                    media_id=incoming_image_media_id,
                 )
             elif incoming_text is not None:
                 sanitized_text = sanitize_user_text(incoming_text, max_chars=2000)
@@ -283,7 +322,8 @@ class InboundTaskProcessor:
                     )
             else:
                 reply_text = (
-                    "Unsupported message type. Please send text or use confirmation buttons."
+                    "Unsupported message type. Please send text, image, "
+                    "or use confirmation buttons."
                 )
 
             if reply_text is not None:
@@ -341,6 +381,105 @@ class InboundTaskProcessor:
                 deterministic_action=deterministic_action,
                 reply_text=reply_text,
             )
+
+    async def _process_operator_photo_message(
+        self,
+        *,
+        payload: InboundTaskPayload,
+        draft_repo: AdDraftRepository,
+        audit_repo: AuditEventRepository,
+        current_draft: AdDraft,
+        language: str,
+        media_id: str,
+    ) -> tuple[AdDraft, str]:
+        try:
+            ingested_photo = await self._operator_photo_ingestor.ingest_whatsapp_image(
+                media_id=media_id
+            )
+        except MediaIngestError as exc:
+            await audit_repo.log(
+                actor="system",
+                action="operator_photo_ingest_failed",
+                operator_phone=payload.operator_phone,
+                metadata={"wamid": payload.wamid, "media_id": media_id, "error": str(exc)},
+            )
+            return (
+                current_draft,
+                "I could not process your photo right now. Please try sending it again.",
+            )
+
+        updated_draft = await draft_repo.update_for_operator_with_version(
+            draft_id=current_draft.id,
+            operator_phone=payload.operator_phone,
+            expected_version=current_draft.version,
+            photo_url=ingested_photo.public_url,
+        )
+        if updated_draft is None:
+            await audit_repo.log(
+                actor="system",
+                action="draft_stale_write_detected",
+                operator_phone=payload.operator_phone,
+                metadata={"wamid": payload.wamid, "media_id": media_id},
+            )
+            return (
+                current_draft,
+                "This draft was already changed. Please refresh and try again.",
+            )
+        current_draft = updated_draft
+
+        detected_ean: str | None = None
+        try:
+            detected_ean = await self._enrichment_service.decode_ean_from_image(
+                ingested_photo.content
+            )
+        except Exception as exc:
+            await audit_repo.log(
+                actor="system",
+                action="barcode_decode_failed",
+                operator_phone=payload.operator_phone,
+                metadata={"wamid": payload.wamid, "media_id": media_id, "error": str(exc)},
+            )
+
+        enrichment_notice: str | None = None
+        try:
+            current_draft, enrichment_notice = await self._enrich_current_draft(
+                payload=payload,
+                draft_repo=draft_repo,
+                audit_repo=audit_repo,
+                current_draft=current_draft,
+                language=language,
+                detected_ean=detected_ean,
+                allow_existing_draft_ean=False,
+            )
+        except Exception as exc:
+            await audit_repo.log(
+                actor="system",
+                action="photo_enrichment_failed",
+                operator_phone=payload.operator_phone,
+                metadata={"wamid": payload.wamid, "media_id": media_id, "error": str(exc)},
+            )
+
+        await audit_repo.log(
+            actor="system",
+            action="operator_photo_ingested",
+            operator_phone=payload.operator_phone,
+            metadata={
+                "wamid": payload.wamid,
+                "media_id": media_id,
+                "media_object_name": ingested_photo.object_name,
+                "photo_url": ingested_photo.public_url,
+                "detected_ean": detected_ean,
+            },
+        )
+
+        reply_text = _build_photo_ingest_reply(
+            draft=current_draft,
+            language=language,
+            detected_ean=detected_ean,
+        )
+        if enrichment_notice:
+            reply_text = f"{reply_text}\n\n{enrichment_notice}"
+        return current_draft, reply_text
 
     async def _enrich_current_draft(
         self,
@@ -504,3 +643,26 @@ def _build_barcode_lookup_reply(
     if language.lower() == "he":
         return f"קיבלתי את הברקוד {ean}, אבל לא מצאתי פרטי מוצר כרגע."
     return f"I received barcode {ean}, but I could not find product details yet."
+
+
+def _build_photo_ingest_reply(
+    *,
+    draft: AdDraft,
+    language: str,
+    detected_ean: str | None,
+) -> str:
+    product_name = draft.product_name or draft.enriched_brand
+    if detected_ean and product_name:
+        if language.lower() == "he":
+            return f"קיבלתי את התמונה, זיהיתי ברקוד {detected_ean}, והמוצר הוא: {product_name}."
+        return (
+            f"I received your photo, detected barcode {detected_ean}, "
+            f"and found product: {product_name}."
+        )
+    if detected_ean:
+        if language.lower() == "he":
+            return f"קיבלתי את התמונה וזיהיתי ברקוד {detected_ean}."
+        return f"I received your photo and detected barcode {detected_ean}."
+    if language.lower() == "he":
+        return "קיבלתי את התמונה ושמרתי אותה בטיוטה."
+    return "I received your photo and saved it to the current draft."

--- a/src/adv_assistant/whatsapp.py
+++ b/src/adv_assistant/whatsapp.py
@@ -2,6 +2,8 @@ from typing import Protocol
 
 import httpx
 
+from adv_assistant.media_ingest import DownloadedMedia, MediaIngestError
+
 
 class WhatsAppClient(Protocol):
     async def send_text(self, *, to_phone: str, message: str) -> None: ...
@@ -49,3 +51,61 @@ class MetaWhatsAppClient:
 
     async def close(self) -> None:
         await self._client.aclose()
+
+
+class MetaWhatsAppMediaClient:
+    def __init__(
+        self,
+        *,
+        access_token: str,
+        graph_api_version: str,
+        timeout_seconds: float = 15.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._graph_api_version = graph_api_version
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            timeout=timeout_seconds,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+    async def download_media(self, *, media_id: str) -> DownloadedMedia:
+        try:
+            metadata_url = f"https://graph.facebook.com/{self._graph_api_version}/{media_id}"
+            metadata_response = await self._client.get(metadata_url)
+            metadata_response.raise_for_status()
+            metadata_payload = metadata_response.json()
+            download_url = metadata_payload.get("url")
+            if not isinstance(download_url, str) or not download_url.strip():
+                raise MediaIngestError("Meta media response does not include download URL")
+
+            media_response = await self._client.get(download_url)
+            media_response.raise_for_status()
+        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+            raise MediaIngestError(f"Meta media download failed: {exc}") from exc
+
+        metadata_content_type = metadata_payload.get("mime_type")
+        response_content_type = media_response.headers.get("content-type")
+        resolved_content_type = _resolve_content_type(
+            response_content_type=response_content_type,
+            metadata_content_type=metadata_content_type
+            if isinstance(metadata_content_type, str)
+            else None,
+        )
+        return DownloadedMedia(content=media_response.content, content_type=resolved_content_type)
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+
+def _resolve_content_type(
+    *,
+    response_content_type: str | None,
+    metadata_content_type: str | None,
+) -> str:
+    if response_content_type:
+        return response_content_type.split(";")[0].strip().lower()
+    if metadata_content_type:
+        return metadata_content_type.split(";")[0].strip().lower()
+    return "application/octet-stream"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,3 +11,9 @@ def test_openai_base_url_preserves_non_empty_value(monkeypatch) -> None:
     monkeypatch.setenv("OPENAI_BASE_URL", "https://example.local/v1")
     settings = Settings.from_env()
     assert settings.openai_base_url == "https://example.local/v1"
+
+
+def test_blank_media_bucket_is_normalized_to_none(monkeypatch) -> None:
+    monkeypatch.setenv("MEDIA_GCS_BUCKET", "  ")
+    settings = Settings.from_env()
+    assert settings.media_gcs_bucket is None

--- a/tests/test_phase6_media.py
+++ b/tests/test_phase6_media.py
@@ -1,0 +1,272 @@
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from adv_assistant.db.base import Base
+from adv_assistant.db.models import AdDraft, AuditEvent, ConversationSession
+from adv_assistant.db.repositories import OperatorRepository
+from adv_assistant.db.session import create_engine, create_session_factory, session_scope
+from adv_assistant.enrichment import EnrichedProduct
+from adv_assistant.media_ingest import (
+    DownloadedMedia,
+    IngestedOperatorPhoto,
+    MediaIngestError,
+    OperatorPhotoIngestor,
+)
+from adv_assistant.media_store import GCSMediaStore, MediaStore, MediaUpload
+from adv_assistant.pipeline import InboundTaskProcessor
+from adv_assistant.tasks_queue import InboundTaskPayload
+
+pytestmark = pytest.mark.anyio
+
+
+class FakeStorageBlob:
+    def __init__(self, bucket: "FakeStorageBucket", name: str) -> None:
+        self._bucket = bucket
+        self._name = name
+
+    def upload_from_string(self, content: bytes, content_type: str) -> None:
+        self._bucket.uploads[self._name] = (content, content_type)
+
+
+class FakeStorageBucket:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.uploads: dict[str, tuple[bytes, str]] = {}
+        self.lifecycle_rules: list[dict[str, object]] = []
+        self.reloaded = False
+
+    def blob(self, name: str) -> FakeStorageBlob:
+        return FakeStorageBlob(self, name)
+
+    def reload(self) -> None:
+        self.reloaded = True
+
+
+class FakeStorageClient:
+    def __init__(self) -> None:
+        self._buckets: dict[str, FakeStorageBucket] = {}
+
+    def bucket(self, name: str) -> FakeStorageBucket:
+        if name not in self._buckets:
+            self._buckets[name] = FakeStorageBucket(name)
+        return self._buckets[name]
+
+
+class StaticMediaStore(MediaStore):
+    def __init__(self, public_url: str) -> None:
+        self.public_url = public_url
+        self.last_upload: tuple[bytes, str, str | None] | None = None
+
+    async def upload_bytes(
+        self,
+        *,
+        content: bytes,
+        content_type: str,
+        object_name: str | None = None,
+        suffix: str | None = None,
+    ) -> MediaUpload:
+        self.last_upload = (content, content_type, suffix)
+        return MediaUpload(
+            object_name=object_name or f"operator-photos/mock{suffix or ''}",
+            public_url=self.public_url,
+        )
+
+    async def has_delete_lifecycle_rule(self, *, days: int) -> bool:
+        return True
+
+    async def close(self) -> None:
+        return None
+
+
+class StaticWhatsAppMediaClient:
+    def __init__(self, downloaded: DownloadedMedia) -> None:
+        self.downloaded = downloaded
+        self.calls = 0
+
+    async def download_media(self, *, media_id: str) -> DownloadedMedia:
+        self.calls += 1
+        return self.downloaded
+
+    async def close(self) -> None:
+        return None
+
+
+class StaticPhotoIngestor(OperatorPhotoIngestor):
+    def __init__(
+        self, result: IngestedOperatorPhoto | None = None, error: str | None = None
+    ) -> None:
+        self._result = result
+        self._error = error
+
+    async def ingest_whatsapp_image(self, *, media_id: str) -> IngestedOperatorPhoto:
+        if self._error:
+            raise MediaIngestError(self._error)
+        if self._result is None:
+            raise MediaIngestError("missing mock result")
+        return self._result
+
+    async def close(self) -> None:
+        return None
+
+
+class StaticEnrichmentService:
+    def __init__(self, *, decoded_ean: str | None, enriched: EnrichedProduct | None) -> None:
+        self._decoded_ean = decoded_ean
+        self._enriched = enriched
+
+    async def decode_ean_from_image(self, image_bytes: bytes) -> str | None:
+        return self._decoded_ean
+
+    async def enrich_by_ean(self, *, ean: str, language: str) -> EnrichedProduct | None:
+        return self._enriched
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.fixture()
+async def session_factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    db_path = tmp_path / "phase6.db"
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    factory = create_session_factory(engine)
+    yield factory
+    await engine.dispose()
+
+
+async def _seed_operator(factory: async_sessionmaker[AsyncSession], phone: str) -> None:
+    async with session_scope(factory) as session:
+        await OperatorRepository(session).create(phone=phone, active=True)
+
+
+async def test_gcs_media_store_upload_and_lifecycle_rule_check() -> None:
+    fake_client = FakeStorageClient()
+    bucket = fake_client.bucket("test-media")
+    bucket.lifecycle_rules = [{"action": {"type": "Delete"}, "condition": {"age": 90}}]
+    store = GCSMediaStore(bucket_name="test-media", client=fake_client)  # type: ignore[arg-type]
+
+    upload = await store.upload_bytes(content=b"img", content_type="image/png", suffix=".png")
+
+    assert upload.object_name.startswith("operator-photos/")
+    assert upload.object_name.endswith(".png")
+    assert upload.public_url.startswith("https://storage.googleapis.com/test-media/")
+    assert bucket.uploads[upload.object_name] == (b"img", "image/png")
+    assert await store.has_delete_lifecycle_rule(days=90) is True
+    assert await store.has_delete_lifecycle_rule(days=30) is False
+    assert bucket.reloaded is True
+
+
+async def test_default_operator_photo_ingestor_uploads_image() -> None:
+    media_store = StaticMediaStore(public_url="https://storage.googleapis.com/bucket/operator.jpg")
+    media_client = StaticWhatsAppMediaClient(
+        DownloadedMedia(content=b"image-bytes", content_type="image/jpeg")
+    )
+    from adv_assistant.media_ingest import DefaultOperatorPhotoIngestor
+
+    ingestor = DefaultOperatorPhotoIngestor(media_client=media_client, media_store=media_store)
+    ingested = await ingestor.ingest_whatsapp_image(media_id="abc123")
+
+    assert ingested.public_url.endswith("/operator.jpg")
+    assert ingested.content == b"image-bytes"
+    assert media_store.last_upload is not None
+    assert media_store.last_upload[2] == ".jpg"
+
+
+async def test_default_operator_photo_ingestor_rejects_non_image() -> None:
+    media_store = StaticMediaStore(public_url="https://storage.googleapis.com/bucket/object")
+    media_client = StaticWhatsAppMediaClient(
+        DownloadedMedia(content=b"binary", content_type="application/pdf")
+    )
+    from adv_assistant.media_ingest import DefaultOperatorPhotoIngestor
+
+    ingestor = DefaultOperatorPhotoIngestor(media_client=media_client, media_store=media_store)
+
+    with pytest.raises(MediaIngestError):
+        await ingestor.ingest_whatsapp_image(media_id="abc123")
+
+
+async def test_pipeline_processes_image_message_and_updates_draft(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    phone = "+972500000601"
+    await _seed_operator(session_factory, phone)
+    processor = InboundTaskProcessor(
+        session_factory,
+        operator_photo_ingestor=StaticPhotoIngestor(
+            IngestedOperatorPhoto(
+                public_url="https://storage.googleapis.com/test-media/operator-photos/p1.jpg",
+                object_name="operator-photos/p1.jpg",
+                content_type="image/jpeg",
+                content=b"jpeg-bytes",
+            )
+        ),
+        enrichment_service=StaticEnrichmentService(
+            decoded_ean="7290004127326",
+            enriched=EnrichedProduct(
+                product_name="קוטג תנובה",
+                brand="תנובה",
+                source="open_food_facts",
+            ),
+        ),
+    )
+
+    result = await processor.process(
+        InboundTaskPayload(
+            wamid="wamid-phase6-image-1",
+            operator_phone=phone,
+            raw_message={"type": "image", "image": {"id": "meta-media-1"}},
+        )
+    )
+
+    assert result.status == "processed"
+    assert result.deterministic_action == "operator_photo_ingest"
+    assert result.reply_text is not None
+    assert "7290004127326" in result.reply_text
+
+    async with session_scope(session_factory) as session:
+        session_obj = (
+            await session.execute(
+                select(ConversationSession).where(ConversationSession.operator_phone == phone)
+            )
+        ).scalar_one()
+        draft = await session.get(AdDraft, session_obj.current_draft_id)
+        assert draft is not None
+        assert draft.photo_url == "https://storage.googleapis.com/test-media/operator-photos/p1.jpg"
+        assert draft.ean == "7290004127326"
+        assert draft.product_name == "קוטג תנובה"
+
+        audit_rows = (
+            await session.execute(
+                select(AuditEvent).where(AuditEvent.action == "operator_photo_ingested")
+            )
+        ).scalars()
+        assert len(list(audit_rows)) == 1
+
+
+async def test_pipeline_image_ingest_failure_is_user_visible(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    phone = "+972500000602"
+    await _seed_operator(session_factory, phone)
+    processor = InboundTaskProcessor(
+        session_factory,
+        operator_photo_ingestor=StaticPhotoIngestor(error="meta 401"),
+        enrichment_service=StaticEnrichmentService(decoded_ean=None, enriched=None),
+    )
+
+    result = await processor.process(
+        InboundTaskPayload(
+            wamid="wamid-phase6-image-err",
+            operator_phone=phone,
+            raw_message={"type": "image", "image": {"id": "meta-media-err"}},
+        )
+    )
+
+    assert result.status == "processed"
+    assert result.reply_text is not None
+    assert "could not process your photo" in result.reply_text.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "fastapi" },
     { name = "google-auth" },
+    { name = "google-cloud-storage" },
     { name = "google-cloud-tasks" },
     { name = "httpx" },
     { name = "openai" },
@@ -40,6 +41,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0,<1.0.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
     { name = "google-auth", specifier = ">=2.39.0,<3.0.0" },
+    { name = "google-cloud-storage", specifier = ">=2.19.0,<3.0.0" },
     { name = "google-cloud-tasks", specifier = ">=2.19.3,<3.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "openai", specifier = ">=1.75.0,<2.0.0" },
@@ -436,6 +438,36 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-core"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/03/ef0bc99d0e0faf4fdbe67ac445e18cdaa74824fd93cd069e7bb6548cb52d/google_cloud_core-2.5.0.tar.gz", hash = "sha256:7c1b7ef5c92311717bd05301aa1a91ffbc565673d3b0b4163a52d8413a186963", size = 36027, upload-time = "2025-10-29T23:17:39.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/20/bfa472e327c8edee00f04beecc80baeddd2ab33ee0e86fd7654da49d45e9/google_cloud_core-2.5.0-py3-none-any.whl", hash = "sha256:67d977b41ae6c7211ee830c7912e41003ea8194bff15ae7d72fd6f51e57acabc", size = 29469, upload-time = "2025-10-29T23:17:38.548Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "2.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/76/4d965702e96bb67976e755bed9828fa50306dca003dbee08b67f41dd265e/google_cloud_storage-2.19.0.tar.gz", hash = "sha256:cd05e9e7191ba6cb68934d8eb76054d9be4562aa89dbc4236feee4d7d51342b2", size = 5535488, upload-time = "2024-12-05T01:35:06.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/94/6db383d8ee1adf45dc6c73477152b82731fa4c4a46d9c1932cc8757e0fd4/google_cloud_storage-2.19.0-py2.py3-none-any.whl", hash = "sha256:aeb971b5c29cf8ab98445082cbfe7b161a1f48ed275822f59ed3f1524ea54fba", size = 131787, upload-time = "2024-12-05T01:35:04.736Z" },
+]
+
+[[package]]
 name = "google-cloud-tasks"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -450,6 +482,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b6/58/0238b71de170b92ef359e53047a3d6ff9618c04ee255cbc6def53ab79e11/google_cloud_tasks-2.21.0.tar.gz", hash = "sha256:d28f33248553faf0ff029e1981aab56cd13bd933635c3bc33aa187675e7e14d1", size = 351784, upload-time = "2026-01-15T13:04:43.071Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/9d/a7f098037fb56f1d69fbfad95f58bf322a4d0dbb6cafcf380c9535730cc0/google_cloud_tasks-2.21.0-py3-none-any.whl", hash = "sha256:4bf288876892a0afac30658fc42925ccb732d3c4433a8ea568de1d67fde738f2", size = 295211, upload-time = "2026-01-15T13:02:52.377Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/d7/520b62a35b23038ff005e334dba3ffc75fcf583bee26723f1fd8fd4b6919/google_resumable_media-2.8.0.tar.gz", hash = "sha256:f1157ed8b46994d60a1bc432544db62352043113684d4e030ee02e77ebe9a1ae", size = 2163265, upload-time = "2025-11-17T15:38:06.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/0b/93afde9cfe012260e9fe1522f35c9b72d6ee222f316586b1f23ecf44d518/google_resumable_media-2.8.0-py3-none-any.whl", hash = "sha256:dd14a116af303845a8d932ddae161a26e86cc229645bc98b39f026f9b1717582", size = 81340, upload-time = "2025-11-17T15:38:05.594Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add  abstraction and  implementation with UUID object naming and public URL output
- add operator photo ingest flow: download image from Meta media endpoint, upload to media store, persist draft 
- wire media services in app startup/config (/ mode, optional lifecycle-rule verification)
- extend inbound pipeline to handle image messages with audit logging and deterministic user replies
- update docs and env examples for Phase 6 media configuration
- add Phase 6 tests for media store, ingest flow, and pipeline image handling

## Validation
- All checks passed!
- ============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/alexanderbol/WebstormProjects/adv-assistant
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.12.1, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 56 items

tests/test_authorization_and_session.py .....                            [  8%]
tests/test_config.py ...                                                 [ 14%]
tests/test_health.py .                                                   [ 16%]
tests/test_ingress_pipeline.py .............                             [ 39%]
tests/test_migrations.py .                                               [ 41%]
tests/test_phase4_llm_boundary.py ........                               [ 55%]
tests/test_phase5_enrichment.py ..........                               [ 73%]
tests/test_phase6_media.py .....                                         [ 82%]
tests/test_repositories.py ...                                           [ 87%]
tests/test_retention.py ....                                             [ 94%]
tests/test_tasks_auth.py ...                                             [100%]

============================== 56 passed in 1.59s ==============================
- docker compose run --rm -v "$PWD":/app app sh -lc "pip install -e . pytest && pytest tests"
Obtaining file:///app
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Collecting pytest
  Downloading pytest-9.0.2-py3-none-any.whl.metadata (7.6 kB)
Collecting iniconfig>=1.0.1 (from pytest)
  Downloading iniconfig-2.3.0-py3-none-any.whl.metadata (2.5 kB)
Collecting packaging>=22 (from pytest)
  Using cached packaging-26.0-py3-none-any.whl.metadata (3.3 kB)
Collecting pluggy<2,>=1.5 (from pytest)
  Using cached pluggy-1.6.0-py3-none-any.whl.metadata (4.8 kB)
Collecting pygments>=2.7.2 (from pytest)
  Downloading pygments-2.19.2-py3-none-any.whl.metadata (2.5 kB)
Collecting aiosqlite<1.0.0,>=0.21.0 (from adv-assistant==0.1.0)
  Downloading aiosqlite-0.22.1-py3-none-any.whl.metadata (4.3 kB)
Collecting alembic<2.0.0,>=1.17.2 (from adv-assistant==0.1.0)
  Downloading alembic-1.18.4-py3-none-any.whl.metadata (7.2 kB)
Collecting asyncpg<1.0.0,>=0.30.0 (from adv-assistant==0.1.0)
  Downloading asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl.metadata (4.4 kB)
Requirement already satisfied: fastapi<1.0.0,>=0.115.0 in /usr/local/lib/python3.12/site-packages (from adv-assistant==0.1.0) (0.134.0)
Collecting google-auth<3.0.0,>=2.39.0 (from adv-assistant==0.1.0)
  Downloading google_auth-2.48.0-py3-none-any.whl.metadata (6.2 kB)
Collecting google-cloud-storage<3.0.0,>=2.19.0 (from adv-assistant==0.1.0)
  Downloading google_cloud_storage-2.19.0-py2.py3-none-any.whl.metadata (9.1 kB)
Collecting google-cloud-tasks<3.0.0,>=2.19.3 (from adv-assistant==0.1.0)
  Downloading google_cloud_tasks-2.21.0-py3-none-any.whl.metadata (9.9 kB)
Requirement already satisfied: httpx<1.0.0,>=0.28.0 in /usr/local/lib/python3.12/site-packages (from adv-assistant==0.1.0) (0.28.1)
Collecting openai<2.0.0,>=1.75.0 (from adv-assistant==0.1.0)
  Downloading openai-1.109.1-py3-none-any.whl.metadata (29 kB)
Collecting psycopg<4.0.0,>=3.2.13 (from psycopg[binary]<4.0.0,>=3.2.13->adv-assistant==0.1.0)
  Downloading psycopg-3.3.3-py3-none-any.whl.metadata (4.3 kB)
Collecting sqlalchemy<3.0.0,>=2.0.44 (from sqlalchemy[asyncio]<3.0.0,>=2.0.44->adv-assistant==0.1.0)
  Downloading sqlalchemy-2.0.47-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl.metadata (9.5 kB)
Requirement already satisfied: uvicorn<1.0.0,>=0.34.0 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]<1.0.0,>=0.34.0->adv-assistant==0.1.0) (0.41.0)
Collecting Mako (from alembic<2.0.0,>=1.17.2->adv-assistant==0.1.0)
  Downloading mako-1.3.10-py3-none-any.whl.metadata (2.9 kB)
Requirement already satisfied: typing-extensions>=4.12 in /usr/local/lib/python3.12/site-packages (from alembic<2.0.0,>=1.17.2->adv-assistant==0.1.0) (4.15.0)
Requirement already satisfied: starlette>=0.46.0 in /usr/local/lib/python3.12/site-packages (from fastapi<1.0.0,>=0.115.0->adv-assistant==0.1.0) (0.52.1)
Requirement already satisfied: pydantic>=2.7.0 in /usr/local/lib/python3.12/site-packages (from fastapi<1.0.0,>=0.115.0->adv-assistant==0.1.0) (2.12.5)
Requirement already satisfied: typing-inspection>=0.4.2 in /usr/local/lib/python3.12/site-packages (from fastapi<1.0.0,>=0.115.0->adv-assistant==0.1.0) (0.4.2)
Requirement already satisfied: annotated-doc>=0.0.2 in /usr/local/lib/python3.12/site-packages (from fastapi<1.0.0,>=0.115.0->adv-assistant==0.1.0) (0.0.4)
Collecting pyasn1-modules>=0.2.1 (from google-auth<3.0.0,>=2.39.0->adv-assistant==0.1.0)
  Downloading pyasn1_modules-0.4.2-py3-none-any.whl.metadata (3.5 kB)
Collecting cryptography>=38.0.3 (from google-auth<3.0.0,>=2.39.0->adv-assistant==0.1.0)
  Downloading cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl.metadata (5.7 kB)
Collecting rsa<5,>=3.1.4 (from google-auth<3.0.0,>=2.39.0->adv-assistant==0.1.0)
  Downloading rsa-4.9.1-py3-none-any.whl.metadata (5.6 kB)
Collecting google-auth<3.0.0,>=2.39.0 (from adv-assistant==0.1.0)
  Downloading google_auth-2.49.0.dev0-py3-none-any.whl.metadata (6.0 kB)
Collecting google-api-core<3.0.0dev,>=2.15.0 (from google-cloud-storage<3.0.0,>=2.19.0->adv-assistant==0.1.0)
  Downloading google_api_core-2.30.0-py3-none-any.whl.metadata (3.1 kB)
Collecting google-cloud-core<3.0dev,>=2.3.0 (from google-cloud-storage<3.0.0,>=2.19.0->adv-assistant==0.1.0)
  Downloading google_cloud_core-2.5.0-py3-none-any.whl.metadata (3.1 kB)
Collecting google-resumable-media>=2.7.2 (from google-cloud-storage<3.0.0,>=2.19.0->adv-assistant==0.1.0)
  Downloading google_resumable_media-2.8.0-py3-none-any.whl.metadata (2.6 kB)
Collecting requests<3.0.0dev,>=2.18.0 (from google-cloud-storage<3.0.0,>=2.19.0->adv-assistant==0.1.0)
  Downloading requests-2.32.5-py3-none-any.whl.metadata (4.9 kB)
Collecting google-crc32c<2.0dev,>=1.0 (from google-cloud-storage<3.0.0,>=2.19.0->adv-assistant==0.1.0)
  Downloading google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl.metadata (1.7 kB)
Collecting grpcio<2.0.0,>=1.33.2 (from google-cloud-tasks<3.0.0,>=2.19.3->adv-assistant==0.1.0)
  Downloading grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl.metadata (3.8 kB)
Collecting proto-plus<2.0.0,>=1.22.3 (from google-cloud-tasks<3.0.0,>=2.19.3->adv-assistant==0.1.0)
  Downloading proto_plus-1.27.1-py3-none-any.whl.metadata (2.2 kB)
Collecting protobuf!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<7.0.0,>=3.20.2 (from google-cloud-tasks<3.0.0,>=2.19.3->adv-assistant==0.1.0)
  Downloading protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl.metadata (593 bytes)
Collecting grpc-google-iam-v1<1.0.0,>=0.14.0 (from google-cloud-tasks<3.0.0,>=2.19.3->adv-assistant==0.1.0)
  Downloading grpc_google_iam_v1-0.14.3-py3-none-any.whl.metadata (9.2 kB)
Requirement already satisfied: anyio in /usr/local/lib/python3.12/site-packages (from httpx<1.0.0,>=0.28.0->adv-assistant==0.1.0) (4.12.1)
Requirement already satisfied: certifi in /usr/local/lib/python3.12/site-packages (from httpx<1.0.0,>=0.28.0->adv-assistant==0.1.0) (2026.2.25)
Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.12/site-packages (from httpx<1.0.0,>=0.28.0->adv-assistant==0.1.0) (1.0.9)
Requirement already satisfied: idna in /usr/local/lib/python3.12/site-packages (from httpx<1.0.0,>=0.28.0->adv-assistant==0.1.0) (3.11)
Requirement already satisfied: h11>=0.16 in /usr/local/lib/python3.12/site-packages (from httpcore==1.*->httpx<1.0.0,>=0.28.0->adv-assistant==0.1.0) (0.16.0)
Collecting distro<2,>=1.7.0 (from openai<2.0.0,>=1.75.0->adv-assistant==0.1.0)
  Downloading distro-1.9.0-py3-none-any.whl.metadata (6.8 kB)
Collecting jiter<1,>=0.4.0 (from openai<2.0.0,>=1.75.0->adv-assistant==0.1.0)
  Downloading jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl.metadata (5.2 kB)
Collecting sniffio (from openai<2.0.0,>=1.75.0->adv-assistant==0.1.0)
  Downloading sniffio-1.3.1-py3-none-any.whl.metadata (3.9 kB)
Collecting tqdm>4 (from openai<2.0.0,>=1.75.0->adv-assistant==0.1.0)
  Downloading tqdm-4.67.3-py3-none-any.whl.metadata (57 kB)
Collecting psycopg-binary==3.3.3 (from psycopg[binary]<4.0.0,>=3.2.13->adv-assistant==0.1.0)
  Downloading psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl.metadata (2.7 kB)
Collecting greenlet>=1 (from sqlalchemy<3.0.0,>=2.0.44->sqlalchemy[asyncio]<3.0.0,>=2.0.44->adv-assistant==0.1.0)
  Downloading greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl.metadata (3.7 kB)
Requirement already satisfied: click>=7.0 in /usr/local/lib/python3.12/site-packages (from uvicorn<1.0.0,>=0.34.0->uvicorn[standard]<1.0.0,>=0.34.0->adv-assistant==0.1.0) (8.3.1)
Requirement already satisfied: httptools>=0.6.3 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]<1.0.0,>=0.34.0->adv-assistant==0.1.0) (0.7.1)
Requirement already satisfied: python-dotenv>=0.13 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]<1.0.0,>=0.34.0->adv-assistant==0.1.0) (1.2.1)
Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]<1.0.0,>=0.34.0->adv-assistant==0.1.0) (6.0.3)
Requirement already satisfied: uvloop>=0.15.1 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]<1.0.0,>=0.34.0->adv-assistant==0.1.0) (0.22.1)
Requirement already satisfied: watchfiles>=0.20 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]<1.0.0,>=0.34.0->adv-assistant==0.1.0) (1.1.1)
Requirement already satisfied: websockets>=10.4 in /usr/local/lib/python3.12/site-packages (from uvicorn[standard]<1.0.0,>=0.34.0->adv-assistant==0.1.0) (16.0)
Collecting cffi>=2.0.0 (from cryptography>=38.0.3->google-auth<3.0.0,>=2.39.0->adv-assistant==0.1.0)
  Downloading cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl.metadata (2.6 kB)
Collecting googleapis-common-protos<2.0.0,>=1.56.3 (from google-api-core<3.0.0dev,>=2.15.0->google-cloud-storage<3.0.0,>=2.19.0->adv-assistant==0.1.0)
  Downloading googleapis_common_protos-1.72.0-py3-none-any.whl.metadata (9.4 kB)
Collecting grpcio-status<2.0.0,>=1.33.2 (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0,>=1.34.1->google-cloud-tasks<3.0.0,>=2.19.3->adv-assistant==0.1.0)
  Downloading grpcio_status-1.78.0-py3-none-any.whl.metadata (1.3 kB)
Collecting pyasn1<0.7.0,>=0.6.1 (from pyasn1-modules>=0.2.1->google-auth<3.0.0,>=2.39.0->adv-assistant==0.1.0)
  Downloading pyasn1-0.6.2-py3-none-any.whl.metadata (8.4 kB)
Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.12/site-packages (from pydantic>=2.7.0->fastapi<1.0.0,>=0.115.0->adv-assistant==0.1.0) (0.7.0)
Requirement already satisfied: pydantic-core==2.41.5 in /usr/local/lib/python3.12/site-packages (from pydantic>=2.7.0->fastapi<1.0.0,>=0.115.0->adv-assistant==0.1.0) (2.41.5)
Collecting charset_normalizer<4,>=2 (from requests<3.0.0dev,>=2.18.0->google-cloud-storage<3.0.0,>=2.19.0->adv-assistant==0.1.0)
  Downloading charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl.metadata (37 kB)
Collecting urllib3<3,>=1.21.1 (from requests<3.0.0dev,>=2.18.0->google-cloud-storage<3.0.0,>=2.19.0->adv-assistant==0.1.0)
  Downloading urllib3-2.6.3-py3-none-any.whl.metadata (6.9 kB)
Collecting MarkupSafe>=0.9.2 (from Mako->alembic<2.0.0,>=1.17.2->adv-assistant==0.1.0)
  Downloading markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl.metadata (2.7 kB)
Collecting pycparser (from cffi>=2.0.0->cryptography>=38.0.3->google-auth<3.0.0,>=2.39.0->adv-assistant==0.1.0)
  Downloading pycparser-3.0-py3-none-any.whl.metadata (8.2 kB)
Downloading pytest-9.0.2-py3-none-any.whl (374 kB)
Downloading aiosqlite-0.22.1-py3-none-any.whl (17 kB)
Downloading alembic-1.18.4-py3-none-any.whl (263 kB)
Downloading asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl (3.4 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.4/3.4 MB 2.7 MB/s eta 0:00:00
Downloading google_auth-2.48.0-py3-none-any.whl (236 kB)
Downloading google_cloud_storage-2.19.0-py2.py3-none-any.whl (131 kB)
Downloading google_cloud_tasks-2.21.0-py3-none-any.whl (295 kB)
Downloading iniconfig-2.3.0-py3-none-any.whl (7.5 kB)
Downloading openai-1.109.1-py3-none-any.whl (948 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 948.6/948.6 kB 2.9 MB/s eta 0:00:00
Using cached packaging-26.0-py3-none-any.whl (74 kB)
Using cached pluggy-1.6.0-py3-none-any.whl (20 kB)
Downloading psycopg-3.3.3-py3-none-any.whl (212 kB)
Downloading psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl (6.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.7/6.7 MB 5.4 MB/s eta 0:00:00
Downloading pygments-2.19.2-py3-none-any.whl (1.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 6.6 MB/s eta 0:00:00
Downloading sqlalchemy-2.0.47-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl (3.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 5.7 MB/s eta 0:00:00
Downloading cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl (4.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.3/4.3 MB 5.0 MB/s eta 0:00:00
Downloading distro-1.9.0-py3-none-any.whl (20 kB)
Downloading google_api_core-2.30.0-py3-none-any.whl (173 kB)
Downloading google_cloud_core-2.5.0-py3-none-any.whl (29 kB)
Downloading google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl (33 kB)
Downloading google_resumable_media-2.8.0-py3-none-any.whl (81 kB)
Downloading greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl (601 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 601.2/601.2 kB 6.4 MB/s eta 0:00:00
Downloading grpc_google_iam_v1-0.14.3-py3-none-any.whl (32 kB)
Downloading grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl (6.5 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.5/6.5 MB 5.5 MB/s eta 0:00:00
Downloading jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (348 kB)
Downloading proto_plus-1.27.1-py3-none-any.whl (50 kB)
Downloading protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl (324 kB)
Downloading pyasn1_modules-0.4.2-py3-none-any.whl (181 kB)
Downloading requests-2.32.5-py3-none-any.whl (64 kB)
Downloading rsa-4.9.1-py3-none-any.whl (34 kB)
Downloading tqdm-4.67.3-py3-none-any.whl (78 kB)
Downloading mako-1.3.10-py3-none-any.whl (78 kB)
Downloading sniffio-1.3.1-py3-none-any.whl (10 kB)
Downloading cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl (220 kB)
Downloading charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl (148 kB)
Downloading googleapis_common_protos-1.72.0-py3-none-any.whl (297 kB)
Downloading grpcio_status-1.78.0-py3-none-any.whl (14 kB)
Downloading markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl (24 kB)
Downloading pyasn1-0.6.2-py3-none-any.whl (83 kB)
Downloading urllib3-2.6.3-py3-none-any.whl (131 kB)
Downloading pycparser-3.0-py3-none-any.whl (48 kB)
Building wheels for collected packages: adv-assistant
  Building editable for adv-assistant (pyproject.toml): started
  Building editable for adv-assistant (pyproject.toml): finished with status 'done'
  Created wheel for adv-assistant: filename=adv_assistant-0.1.0-py3-none-any.whl size=4332 sha256=7d5c76a163b83d62f7483044d9e00a2b5e273403c55fdb8a3eb29dd53f1361b3
  Stored in directory: /tmp/pip-ephem-wheel-cache-pesu32ov/wheels/54/1b/b7/aa63e25c8f14f4f2ae7b04e6097bdecb770e455c5c1ee0a600
Successfully built adv-assistant
Installing collected packages: urllib3, tqdm, sniffio, pygments, pycparser, pyasn1, psycopg-binary, psycopg, protobuf, pluggy, packaging, MarkupSafe, jiter, iniconfig, grpcio, greenlet, google-crc32c, distro, charset_normalizer, asyncpg, aiosqlite, sqlalchemy, rsa, requests, pytest, pyasn1-modules, proto-plus, Mako, googleapis-common-protos, google-resumable-media, cffi, openai, grpcio-status, cryptography, alembic, grpc-google-iam-v1, google-auth, google-api-core, google-cloud-core, google-cloud-tasks, google-cloud-storage, adv-assistant
  Attempting uninstall: adv-assistant
    Found existing installation: adv-assistant 0.1.0
    Uninstalling adv-assistant-0.1.0:
      Successfully uninstalled adv-assistant-0.1.0
Successfully installed Mako-1.3.10 MarkupSafe-3.0.3 adv-assistant-0.1.0 aiosqlite-0.22.1 alembic-1.18.4 asyncpg-0.31.0 cffi-2.0.0 charset_normalizer-3.4.4 cryptography-46.0.5 distro-1.9.0 google-api-core-2.30.0 google-auth-2.48.0 google-cloud-core-2.5.0 google-cloud-storage-2.19.0 google-cloud-tasks-2.21.0 google-crc32c-1.8.0 google-resumable-media-2.8.0 googleapis-common-protos-1.72.0 greenlet-3.3.2 grpc-google-iam-v1-0.14.3 grpcio-1.78.0 grpcio-status-1.78.0 iniconfig-2.3.0 jiter-0.13.0 openai-1.109.1 packaging-26.0 pluggy-1.6.0 proto-plus-1.27.1 protobuf-6.33.5 psycopg-3.3.3 psycopg-binary-3.3.3 pyasn1-0.6.2 pyasn1-modules-0.4.2 pycparser-3.0 pygments-2.19.2 pytest-9.0.2 requests-2.32.5 rsa-4.9.1 sniffio-1.3.1 sqlalchemy-2.0.47 tqdm-4.67.3 urllib3-2.6.3
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /app
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 56 items

tests/test_authorization_and_session.py .....                            [  8%]
tests/test_config.py ...                                                 [ 14%]
tests/test_health.py .                                                   [ 16%]
tests/test_ingress_pipeline.py .............                             [ 39%]
tests/test_migrations.py .                                               [ 41%]
tests/test_phase4_llm_boundary.py ........                               [ 55%]
tests/test_phase5_enrichment.py ..........                               [ 73%]
tests/test_phase6_media.py .....                                         [ 82%]
tests/test_repositories.py ...                                           [ 87%]
tests/test_retention.py ....                                             [ 94%]
tests/test_tasks_auth.py ...                                             [100%]

============================== 56 passed in 2.51s ==============================
