### PR TITLE
Stage 1 MVP: Operator CMS routing + basic admin mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ TASKS_MODE=inline
 REPLAY_WINDOW_SECONDS=300
 UNAUTHORIZED_REJECTION_WINDOW_MINUTES=60
 UNAUTHORIZED_REJECTION_MESSAGE="You are not authorized to use this assistant. Please contact your administrator."
+ADMIN_BASIC_USERNAME=admin
+ADMIN_BASIC_PASSWORD=change-me-admin-password
 
 # Cloud Tasks settings (required only for TASKS_MODE=cloud)
 GCP_PROJECT_ID=ads-assistant-488908

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@
 - Runtime modes:
   - `TASKS_MODE=inline` for local development (task payload is processed in-process)
   - `TASKS_MODE=cloud` for Cloud Tasks enqueue
+- Admin mapping UI auth:
+  - `ADMIN_BASIC_USERNAME`
+  - `ADMIN_BASIC_PASSWORD`
+  - if these are missing, `/admin` and admin API endpoints return `503 Admin authentication is not configured`
+  - local dev tip: run via `make run` so `.env` is loaded into process environment
 - Cloud mode requires:
   - `GCP_PROJECT_ID`, `TASKS_REGION`, `TASKS_QUEUE`
   - `TASKS_HANDLER_URL`

--- a/alembic/versions/20260305_0005_operator_cms_mapping.py
+++ b/alembic/versions/20260305_0005_operator_cms_mapping.py
@@ -1,0 +1,32 @@
+"""add operator cms mapping fields
+
+Revision ID: 20260305_0005
+Revises: 20260304_0004
+Create Date: 2026-03-05 12:30:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260305_0005"
+down_revision: str | None = "20260304_0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("operator", sa.Column("meta_user_id", sa.String(length=128), nullable=True))
+    op.add_column("operator", sa.Column("cms_campaign_id", sa.Integer(), nullable=True))
+    op.add_column("operator", sa.Column("cms_playlist_id", sa.Integer(), nullable=True))
+    op.create_index("ix_operator_meta_user_id", "operator", ["meta_user_id"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_operator_meta_user_id", table_name="operator")
+    op.drop_column("operator", "cms_playlist_id")
+    op.drop_column("operator", "cms_campaign_id")
+    op.drop_column("operator", "meta_user_id")

--- a/docs/2026-03-05-stage1-operator-cms-routing.md
+++ b/docs/2026-03-05-stage1-operator-cms-routing.md
@@ -1,0 +1,84 @@
+# Stage 1 Implementation Summary (March 5, 2026)
+
+This document summarizes the implemented MVP Stage 1 scope: per-operator CMS routing and a basic admin mapping UI/API.
+
+## Scope Delivered
+
+1. Per-operator CMS mapping persisted in DB.
+2. Publish routing uses operator mapping (campaign/playlist) per request.
+3. Publish is blocked when operator is not mapped, with fixed Hebrew message.
+4. Basic admin UI/API protected by HTTP Basic Auth.
+5. Audit events for admin mapping actions and blocked publish attempts.
+
+## Data Model and Migration
+
+### New `operator` columns
+- `meta_user_id` (nullable, unique, indexed)
+- `cms_campaign_id` (nullable int)
+- `cms_playlist_id` (nullable int)
+
+### Migration
+- `alembic/versions/20260305_0005_operator_cms_mapping.py`
+
+### Startup schema guard
+- App startup validates the new `operator` columns and fails fast with a migration instruction when missing.
+
+## Repository Changes
+
+In `OperatorRepository`:
+- `create(...)` now accepts optional mapping fields.
+- Added `get_by_meta_user_id(...)`.
+- Added `update_cms_mapping(...)`.
+
+## Publish Flow Changes
+
+### Routing behavior
+- `publish_generated_image(...)` accepts per-call `campaign_id` / `playlist_id` override.
+- Pipeline passes operator mapping values to CMS publisher on confirm-publish.
+
+### Block behavior (missing mapping)
+- Bot response:
+  - "אתה לא מחובר למערכת כרגע, פנה לתמיכה כדי לייצר את החיבור"
+- No CMS side effects.
+- Audit event emitted: `publish_blocked_operator_not_connected`.
+
+## Admin API/UI
+
+### Authentication
+- Environment variables:
+  - `ADMIN_BASIC_USERNAME`
+  - `ADMIN_BASIC_PASSWORD`
+- If missing, admin endpoints return `503`.
+
+### Endpoints
+- `GET /admin` – minimal mapping form UI.
+- `POST /admin/operators/connect` – create/update mapping.
+- `GET /admin/operators/by-phone/{phone}` – fetch mapping.
+- `GET /admin/operators/by-meta/{meta_user_id}` – fetch mapping.
+
+### Behavior
+- Supports lookup by phone and/or existing Meta user ID.
+- Can create operator when phone is provided and operator does not exist.
+- Emits admin audit events:
+  - `admin_operator_created_with_cms_mapping`
+  - `admin_operator_cms_mapping_updated`
+
+## Test Coverage Added/Updated
+
+- Migration tests:
+  - `tests/test_migrations.py`
+- Repository tests:
+  - `tests/test_repositories.py`
+- CMS publish integration tests:
+  - `tests/test_phase8_cms_publish.py`
+- Admin tests:
+  - `tests/test_admin_mvp.py`
+
+## Local Run Notes
+
+1. Run migrations:
+   - `uv run alembic upgrade head`
+2. Start app with env loading:
+   - `make run`
+3. Open admin page:
+   - `/admin`

--- a/docs/mvp-priority-plan-2026-03-05.md
+++ b/docs/mvp-priority-plan-2026-03-05.md
@@ -12,6 +12,12 @@ This document captures the agreed MVP execution order, acceptance rules, and tes
 5. `store_type` is free text.
 6. MVP includes a basic admin interface (Basic Auth + minimal web form) to connect operator -> CMS mapping.
 
+## Current Status (March 5, 2026)
+
+- Stage 1 implementation is complete in code and tests.
+- Stage 2 is the next active sprint focus.
+- Stage 3 remains release validation once Stage 2 is merged.
+
 ## Stage 1 — Multi-Operator CMS Routing + Basic Admin
 
 ### Deliverables

--- a/src/adv_assistant/cms_cityscreen.py
+++ b/src/adv_assistant/cms_cityscreen.py
@@ -30,6 +30,8 @@ class CMSPublisher(Protocol):
         *,
         image_url: str,
         title: str,
+        campaign_id: int | None = None,
+        playlist_id: int | None = None,
     ) -> CMSPublishResult: ...
 
     async def close(self) -> None: ...
@@ -45,6 +47,8 @@ class NoopCMSPublisher:
         *,
         image_url: str,
         title: str,
+        campaign_id: int | None = None,
+        playlist_id: int | None = None,
     ) -> CMSPublishResult:
         raise CMSPublishError("CMS publishing is not configured")
 
@@ -85,11 +89,15 @@ class CityScreenCMSPublisher:
         *,
         image_url: str,
         title: str,
+        campaign_id: int | None = None,
+        playlist_id: int | None = None,
     ) -> CMSPublishResult:
+        resolved_campaign_id = campaign_id if campaign_id is not None else self._campaign_id
+        resolved_playlist_id = playlist_id if playlist_id is not None else self._playlist_id
         self._debug(
             "publish start campaign_id=%s playlist_id=%s image_url=%s",
-            self._campaign_id,
-            self._playlist_id,
+            resolved_campaign_id,
+            resolved_playlist_id,
             image_url,
         )
         image_bytes, content_type = await self._download_image(image_url=image_url)
@@ -137,10 +145,14 @@ class CityScreenCMSPublisher:
             width=width,
             height=height,
             title=title,
+            campaign_id=resolved_campaign_id,
         )
         self._debug("advertisement created advertisement_id=%s", advertisement_id)
 
-        slot_id = await self._append_advertisement_to_playlist(advertisement_id=advertisement_id)
+        slot_id = await self._append_advertisement_to_playlist(
+            advertisement_id=advertisement_id,
+            playlist_id=resolved_playlist_id,
+        )
         self._debug("playlist append done slot_id=%s", slot_id)
         return CMSPublishResult(
             file_id=file_id,
@@ -199,8 +211,9 @@ class CityScreenCMSPublisher:
         width: int,
         height: int,
         title: str,
+        campaign_id: int,
     ) -> int:
-        url = f"{self._base_url}/api/v1.4/advertiser/campaigns/{self._campaign_id}/advertisements"
+        url = f"{self._base_url}/api/v1.4/advertiser/campaigns/{campaign_id}/advertisements"
         payload = {
             "title": title[:120],
             "type": "picture",
@@ -220,8 +233,13 @@ class CityScreenCMSPublisher:
             raise CMSPublishError("create advertisement returned invalid payload")
         return _as_int(body.get("id"), field="advertisement.id")
 
-    async def _append_advertisement_to_playlist(self, *, advertisement_id: int) -> int | None:
-        playlist = await self._load_playlist()
+    async def _append_advertisement_to_playlist(
+        self,
+        *,
+        advertisement_id: int,
+        playlist_id: int,
+    ) -> int | None:
+        playlist = await self._load_playlist(playlist_id=playlist_id)
         playlist_name = playlist.get("name")
         if not isinstance(playlist_name, str) or not playlist_name.strip():
             raise CMSPublishError("playlist response did not include valid name")
@@ -251,7 +269,7 @@ class CityScreenCMSPublisher:
             }
         )
         update_payload = {"name": playlist_name, "slots": slots_payload}
-        update_url = f"{self._base_url}/api/v1.4/playlists/{self._playlist_id}"
+        update_url = f"{self._base_url}/api/v1.4/playlists/{playlist_id}"
         update_response = await self._client.post(
             update_url,
             headers=self._headers,
@@ -273,8 +291,8 @@ class CityScreenCMSPublisher:
                 return _as_optional_int(slot.get("id"))
         return None
 
-    async def _load_playlist(self) -> dict[str, Any]:
-        url = f"{self._base_url}/api/v1.4/playlists/{self._playlist_id}"
+    async def _load_playlist(self, *, playlist_id: int) -> dict[str, Any]:
+        url = f"{self._base_url}/api/v1.4/playlists/{playlist_id}"
         response = await self._client.get(url, headers=self._headers)
         _raise_for_status(response, "load playlist")
         payload = _safe_json(response, "load playlist")

--- a/src/adv_assistant/config.py
+++ b/src/adv_assistant/config.py
@@ -72,6 +72,8 @@ class Settings:
     tasks_service_account_email: str | None = None
     tasks_oidc_audience: str | None = None
     tasks_allowed_service_account_email: str | None = None
+    admin_basic_username: str | None = None
+    admin_basic_password: str | None = None
 
     openai_api_key: str | None = None
     openai_base_url: str | None = None
@@ -152,6 +154,8 @@ class Settings:
             tasks_service_account_email=os.getenv("TASKS_SERVICE_ACCOUNT_EMAIL"),
             tasks_oidc_audience=os.getenv("TASKS_OIDC_AUDIENCE"),
             tasks_allowed_service_account_email=os.getenv("TASKS_ALLOWED_SERVICE_ACCOUNT_EMAIL"),
+            admin_basic_username=_optional_env("ADMIN_BASIC_USERNAME"),
+            admin_basic_password=_optional_env("ADMIN_BASIC_PASSWORD"),
             openai_api_key=os.getenv("OPENAI_API_KEY"),
             openai_base_url=_optional_env("OPENAI_BASE_URL"),
             llm_classification_model=os.getenv("LLM_CLASSIFICATION_MODEL", "gpt-4o-mini"),

--- a/src/adv_assistant/db/models.py
+++ b/src/adv_assistant/db/models.py
@@ -29,9 +29,14 @@ class Operator(TimestampMixin, Base):
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
     phone: Mapped[str] = mapped_column(String(32), nullable=False, unique=True, index=True)
     display_name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    meta_user_id: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, unique=True, index=True
+    )
     language: Mapped[str] = mapped_column(String(2), nullable=False, default=Language.HE.value)
     currency: Mapped[str] = mapped_column(String(3), nullable=False, default="ILS")
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, index=True)
+    cms_campaign_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cms_playlist_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     business_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
     logo_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     brand_colors: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)

--- a/src/adv_assistant/db/repositories.py
+++ b/src/adv_assistant/db/repositories.py
@@ -29,20 +29,26 @@ class OperatorRepository:
         self,
         *,
         phone: str,
+        meta_user_id: str | None = None,
         display_name: str | None = None,
         language: str = "he",
         currency: str = "ILS",
         active: bool = True,
+        cms_campaign_id: int | None = None,
+        cms_playlist_id: int | None = None,
         business_name: str | None = None,
         logo_url: str | None = None,
         brand_colors: list[str] | None = None,
     ) -> Operator:
         operator = Operator(
             phone=phone,
+            meta_user_id=meta_user_id,
             display_name=display_name,
             language=language,
             currency=currency,
             active=active,
+            cms_campaign_id=cms_campaign_id,
+            cms_playlist_id=cms_playlist_id,
             business_name=business_name,
             logo_url=logo_url,
             brand_colors=brand_colors,
@@ -53,6 +59,12 @@ class OperatorRepository:
 
     async def get_by_phone(self, phone: str) -> Operator | None:
         result = await self.session.execute(select(Operator).where(Operator.phone == phone))
+        return result.scalar_one_or_none()
+
+    async def get_by_meta_user_id(self, meta_user_id: str) -> Operator | None:
+        result = await self.session.execute(
+            select(Operator).where(Operator.meta_user_id == meta_user_id)
+        )
         return result.scalar_one_or_none()
 
     async def list_active(self) -> list[Operator]:
@@ -85,6 +97,30 @@ class OperatorRepository:
             values["brand_colors"] = brand_colors
         if len(values) == 1:
             return False
+        result = await self.session.execute(
+            update(Operator).where(Operator.phone == phone).values(**values)
+        )
+        await self.session.flush()
+        return (result.rowcount or 0) > 0
+
+    async def update_cms_mapping(
+        self,
+        phone: str,
+        *,
+        meta_user_id: str | None | object = _UNSET,
+        cms_campaign_id: int | None | object = _UNSET,
+        cms_playlist_id: int | None | object = _UNSET,
+    ) -> bool:
+        values: dict[str, Any] = {"updated_at": utcnow()}
+        if meta_user_id is not _UNSET:
+            values["meta_user_id"] = meta_user_id
+        if cms_campaign_id is not _UNSET:
+            values["cms_campaign_id"] = cms_campaign_id
+        if cms_playlist_id is not _UNSET:
+            values["cms_playlist_id"] = cms_playlist_id
+        if len(values) == 1:
+            return False
+
         result = await self.session.execute(
             update(Operator).where(Operator.phone == phone).values(**values)
         )

--- a/src/adv_assistant/main.py
+++ b/src/adv_assistant/main.py
@@ -1,12 +1,16 @@
 import logging
+import secrets
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Annotated
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import HTMLResponse, PlainTextResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from pydantic import BaseModel, Field
 from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from adv_assistant.ad_generation import (
@@ -17,6 +21,7 @@ from adv_assistant.ad_generation import (
 from adv_assistant.cms_cityscreen import CityScreenCMSPublisher, CMSPublisher, NoopCMSPublisher
 from adv_assistant.config import Settings
 from adv_assistant.db.base import utcnow
+from adv_assistant.db.models import Operator
 from adv_assistant.db.repositories import (
     AuditEventRepository,
     OperatorRepository,
@@ -31,6 +36,7 @@ from adv_assistant.enrichment import (
 from adv_assistant.ingress import (
     extract_inbound_messages,
     is_within_replay_window,
+    normalize_phone_number,
     verify_x_hub_signature,
 )
 from adv_assistant.llm_gateway import (
@@ -66,6 +72,24 @@ from adv_assistant.whatsapp import (
 )
 
 logger = logging.getLogger(__name__)
+
+_ADMIN_AUTH_CHALLENGE = {"WWW-Authenticate": "Basic"}
+
+
+class OperatorCMSConnectRequest(BaseModel):
+    phone: str | None = Field(default=None, max_length=32)
+    meta_user_id: str | None = Field(default=None, max_length=128)
+    cms_campaign_id: int = Field(gt=0)
+    cms_playlist_id: int = Field(gt=0)
+    active: bool = True
+
+
+class OperatorCMSMappingResponse(BaseModel):
+    phone: str
+    meta_user_id: str | None
+    cms_campaign_id: int | None
+    cms_playlist_id: int | None
+    active: bool
 
 
 def _build_task_authorizer(settings: Settings) -> TaskRequestAuthorizer:
@@ -246,7 +270,14 @@ async def _validate_schema_compatibility(
     settings: Settings,
 ) -> None:
     required_columns_by_table: dict[str, set[str]] = {
-        "operator": {"business_name", "logo_url", "brand_colors"},
+        "operator": {
+            "business_name",
+            "logo_url",
+            "brand_colors",
+            "meta_user_id",
+            "cms_campaign_id",
+            "cms_playlist_id",
+        },
         "conversation_session": {"pending_upload_type"},
         "ad_draft": {"product_brand"},
     }
@@ -500,6 +531,253 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     HubMode = Annotated[str, Query(alias="hub.mode")]
     HubToken = Annotated[str, Query(alias="hub.verify_token")]
     HubChallenge = Annotated[str, Query(alias="hub.challenge")]
+    basic_auth = HTTPBasic(auto_error=False)
+
+    def _normalize_optional_text(value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    def _normalize_optional_phone(value: str | None) -> str | None:
+        normalized = _normalize_optional_text(value)
+        if normalized is None:
+            return None
+        return normalize_phone_number(normalized)
+
+    async def _require_admin(
+        credentials: Annotated[HTTPBasicCredentials | None, Depends(basic_auth)],
+    ) -> None:
+        expected_username = current_settings.admin_basic_username
+        expected_password = current_settings.admin_basic_password
+        if not expected_username or not expected_password:
+            raise HTTPException(status_code=503, detail="Admin authentication is not configured")
+        if credentials is None:
+            raise HTTPException(
+                status_code=401,
+                detail="Missing admin credentials",
+                headers=_ADMIN_AUTH_CHALLENGE,
+            )
+        username_ok = secrets.compare_digest(credentials.username, expected_username)
+        password_ok = secrets.compare_digest(credentials.password, expected_password)
+        if not (username_ok and password_ok):
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid admin credentials",
+                headers=_ADMIN_AUTH_CHALLENGE,
+            )
+
+    AdminAuthDep = Annotated[None, Depends(_require_admin)]
+
+    def _to_operator_mapping_response(operator: Operator) -> OperatorCMSMappingResponse:
+        return OperatorCMSMappingResponse(
+            phone=operator.phone,
+            meta_user_id=operator.meta_user_id,
+            cms_campaign_id=operator.cms_campaign_id,
+            cms_playlist_id=operator.cms_playlist_id,
+            active=operator.active,
+        )
+
+    async def _upsert_operator_cms_mapping(
+        *,
+        session: AsyncSession,
+        phone: str | None,
+        meta_user_id: str | None,
+        cms_campaign_id: int,
+        cms_playlist_id: int,
+        active: bool,
+    ):
+        normalized_phone = _normalize_optional_phone(phone)
+        normalized_meta_user_id = _normalize_optional_text(meta_user_id)
+
+        if normalized_phone is None and normalized_meta_user_id is None:
+            raise HTTPException(
+                status_code=422,
+                detail="Either phone or meta_user_id is required",
+            )
+
+        operator_repo = OperatorRepository(session)
+        audit_repo = AuditEventRepository(session)
+
+        operator = None
+        if normalized_phone is not None:
+            operator = await operator_repo.get_by_phone(normalized_phone)
+        if operator is None and normalized_meta_user_id is not None:
+            operator = await operator_repo.get_by_meta_user_id(normalized_meta_user_id)
+
+        if operator is None:
+            if normalized_phone is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail="Operator not found for the provided meta_user_id",
+                )
+            operator = await operator_repo.create(
+                phone=normalized_phone,
+                meta_user_id=normalized_meta_user_id,
+                active=active,
+                cms_campaign_id=cms_campaign_id,
+                cms_playlist_id=cms_playlist_id,
+            )
+            await audit_repo.log(
+                actor="admin",
+                action="admin_operator_created_with_cms_mapping",
+                operator_phone=operator.phone,
+                metadata={
+                    "cms_campaign_id": cms_campaign_id,
+                    "cms_playlist_id": cms_playlist_id,
+                    "meta_user_id": normalized_meta_user_id,
+                },
+            )
+            return operator
+
+        if normalized_phone is not None and operator.phone != normalized_phone:
+            raise HTTPException(
+                status_code=409,
+                detail="Provided phone does not match the located operator",
+            )
+
+        target_meta_user_id = (
+            normalized_meta_user_id
+            if normalized_meta_user_id is not None
+            else operator.meta_user_id
+        )
+        await operator_repo.update_cms_mapping(
+            operator.phone,
+            meta_user_id=target_meta_user_id,
+            cms_campaign_id=cms_campaign_id,
+            cms_playlist_id=cms_playlist_id,
+        )
+        if operator.active != active:
+            await operator_repo.set_active(operator.phone, active)
+
+        updated_operator = await operator_repo.get_by_phone(operator.phone)
+        if updated_operator is None:
+            raise HTTPException(status_code=500, detail="Operator update failed")
+
+        await audit_repo.log(
+            actor="admin",
+            action="admin_operator_cms_mapping_updated",
+            operator_phone=updated_operator.phone,
+            metadata={
+                "cms_campaign_id": updated_operator.cms_campaign_id,
+                "cms_playlist_id": updated_operator.cms_playlist_id,
+                "meta_user_id": updated_operator.meta_user_id,
+                "active": updated_operator.active,
+            },
+        )
+        return updated_operator
+
+    @app.get("/admin", response_class=HTMLResponse)
+    async def admin_home(_: AdminAuthDep) -> HTMLResponse:
+        return HTMLResponse(
+            content="""
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Adv Assistant Admin</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2rem; max-width: 760px; }
+      fieldset { margin-bottom: 1rem; padding: 1rem; }
+      label { display: block; margin-top: 0.6rem; }
+      input[type=text], input[type=number] { width: 100%; padding: 0.4rem; }
+      button { margin-top: 1rem; padding: 0.5rem 1rem; }
+      .note { color: #444; font-size: 0.95rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Operator CMS Mapping</h1>
+    <p class="note">Provide phone or an existing Meta user ID, plus campaign/playlist IDs.</p>
+    <form id="mapping-form">
+      <fieldset>
+        <label>Phone</label>
+        <input id="phone" type="text" name="phone" placeholder="+9725..." />
+
+        <label>Meta User ID (optional)</label>
+        <input id="meta_user_id" type="text" name="meta_user_id" placeholder="meta-user-id" />
+
+        <label>CMS Campaign ID</label>
+        <input id="cms_campaign_id" type="number" name="cms_campaign_id" min="1" required />
+
+        <label>CMS Playlist ID</label>
+        <input id="cms_playlist_id" type="number" name="cms_playlist_id" min="1" required />
+
+        <label><input id="active" type="checkbox" name="active" checked /> Active</label>
+
+        <button type="submit">Save Mapping</button>
+      </fieldset>
+    </form>
+    <pre id="result"></pre>
+    <script>
+      const form = document.getElementById('mapping-form');
+      const result = document.getElementById('result');
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const payload = {
+          phone: document.getElementById('phone').value || null,
+          meta_user_id: document.getElementById('meta_user_id').value || null,
+          cms_campaign_id: Number(document.getElementById('cms_campaign_id').value),
+          cms_playlist_id: Number(document.getElementById('cms_playlist_id').value),
+          active: document.getElementById('active').checked,
+        };
+        const response = await fetch('/admin/operators/connect', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const body = await response.text();
+        result.textContent = `${response.status} ${response.statusText}\\n${body}`;
+      });
+    </script>
+  </body>
+</html>
+""".strip()
+        )
+
+    @app.post("/admin/operators/connect", response_model=OperatorCMSMappingResponse)
+    async def admin_connect_operator_json(
+        body: OperatorCMSConnectRequest,
+        session: DbSessionDep,
+        _: AdminAuthDep,
+    ) -> OperatorCMSMappingResponse:
+        try:
+            operator = await _upsert_operator_cms_mapping(
+                session=session,
+                phone=body.phone,
+                meta_user_id=body.meta_user_id,
+                cms_campaign_id=body.cms_campaign_id,
+                cms_playlist_id=body.cms_playlist_id,
+                active=body.active,
+            )
+        except IntegrityError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail="meta_user_id already assigned to another operator",
+            ) from exc
+        return _to_operator_mapping_response(operator)
+
+    @app.get("/admin/operators/by-phone/{phone}", response_model=OperatorCMSMappingResponse)
+    async def admin_get_operator_by_phone(
+        phone: str,
+        session: DbSessionDep,
+        _: AdminAuthDep,
+    ) -> OperatorCMSMappingResponse:
+        normalized_phone = normalize_phone_number(phone)
+        operator = await OperatorRepository(session).get_by_phone(normalized_phone)
+        if operator is None:
+            raise HTTPException(status_code=404, detail="Operator not found")
+        return _to_operator_mapping_response(operator)
+
+    @app.get("/admin/operators/by-meta/{meta_user_id}", response_model=OperatorCMSMappingResponse)
+    async def admin_get_operator_by_meta(
+        meta_user_id: str,
+        session: DbSessionDep,
+        _: AdminAuthDep,
+    ) -> OperatorCMSMappingResponse:
+        operator = await OperatorRepository(session).get_by_meta_user_id(meta_user_id)
+        if operator is None:
+            raise HTTPException(status_code=404, detail="Operator not found")
+        return _to_operator_mapping_response(operator)
 
     @app.get("/health")
     async def health() -> dict[str, str]:

--- a/src/adv_assistant/pipeline.py
+++ b/src/adv_assistant/pipeline.py
@@ -220,6 +220,7 @@ class InboundTaskProcessor:
                         draft_repo=draft_repo,
                         published_repo=published_repo,
                         audit_repo=audit_repo,
+                        operator=operator,
                         current_draft=current_draft,
                         language=operator.language,
                     )
@@ -771,6 +772,7 @@ class InboundTaskProcessor:
         draft_repo: AdDraftRepository,
         published_repo: PublishedAdRepository,
         audit_repo: AuditEventRepository,
+        operator: Operator,
         current_draft: AdDraft,
         language: str,
     ) -> tuple[AdDraft, str]:
@@ -778,6 +780,18 @@ class InboundTaskProcessor:
             if language.lower() == "he":
                 return current_draft, "אין כרגע תמונת תצוגה מוכנה לפרסום."
             return current_draft, "There is no generated preview image ready for publishing."
+
+        if operator.cms_campaign_id is None or operator.cms_playlist_id is None:
+            await audit_repo.log(
+                actor="system",
+                action="publish_blocked_operator_not_connected",
+                operator_phone=payload.operator_phone,
+                metadata={
+                    "wamid": payload.wamid,
+                    "draft_id": str(current_draft.id),
+                },
+            )
+            return current_draft, _cms_not_connected_reply()
 
         if not self._cms_publisher.enabled:
             if language.lower() == "he":
@@ -803,6 +817,8 @@ class InboundTaskProcessor:
             publish_result = await self._cms_publisher.publish_generated_image(
                 image_url=current_draft.rendered_image_url,
                 title=title,
+                campaign_id=operator.cms_campaign_id,
+                playlist_id=operator.cms_playlist_id,
             )
             cms_id = str(publish_result.advertisement_id)
             existing = await published_repo.get_by_cms_id(cms_id)
@@ -829,6 +845,8 @@ class InboundTaskProcessor:
                     "file_id": publish_result.file_id,
                     "advertisement_id": publish_result.advertisement_id,
                     "slot_id": publish_result.slot_id,
+                    "campaign_id": operator.cms_campaign_id,
+                    "playlist_id": operator.cms_playlist_id,
                 },
             )
             logger.info(
@@ -1298,6 +1316,10 @@ def _publish_buttons_prompt(language: str) -> str:
     if language.lower() == "he":
         return "לפרסם את המודעה הזו ל-CMS?"
     return "Publish this ad to CMS?"
+
+
+def _cms_not_connected_reply() -> str:
+    return "אתה לא מחובר למערכת כרגע, פנה לתמיכה כדי לייצר את החיבור"
 
 
 def _generation_failed_reply(language: str) -> str:

--- a/tests/test_admin_mvp.py
+++ b/tests/test_admin_mvp.py
@@ -1,0 +1,161 @@
+import base64
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from adv_assistant.config import Settings
+from adv_assistant.db.base import Base
+from adv_assistant.db.repositories import OperatorRepository
+from adv_assistant.db.session import session_scope
+from adv_assistant.main import create_app
+
+pytestmark = pytest.mark.anyio
+
+
+def _basic_auth_header(username: str, password: str) -> dict[str, str]:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+@pytest.fixture()
+async def admin_app(tmp_path: Path):
+    db_path = tmp_path / "admin_mvp.db"
+    settings = Settings(
+        app_name="adv-assistant-admin-test",
+        database_url=f"sqlite+aiosqlite:///{db_path}",
+        tasks_mode="inline",
+        admin_basic_username="admin",
+        admin_basic_password="secret",
+    )
+    app = create_app(settings)
+    async with app.state.engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    await app.router.startup()
+    yield app
+    await app.router.shutdown()
+
+
+@pytest.fixture()
+async def admin_client(admin_app) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+async def _seed_operator(app, *, phone: str) -> None:
+    async with session_scope(app.state.session_factory) as session:
+        await OperatorRepository(session).create(phone=phone, active=True)
+
+
+async def test_admin_endpoints_require_basic_auth(admin_client: AsyncClient) -> None:
+    response_home = await admin_client.get("/admin")
+    assert response_home.status_code == 401
+
+    response_connect = await admin_client.post(
+        "/admin/operators/connect",
+        json={
+            "phone": "+972500000900",
+            "cms_campaign_id": 157,
+            "cms_playlist_id": 139,
+        },
+    )
+    assert response_connect.status_code == 401
+
+
+async def test_admin_can_create_operator_mapping_and_fetch_it(admin_client: AsyncClient) -> None:
+    headers = _basic_auth_header("admin", "secret")
+    connect = await admin_client.post(
+        "/admin/operators/connect",
+        headers=headers,
+        json={
+            "phone": "972500000901",
+            "meta_user_id": "meta-901",
+            "cms_campaign_id": 157,
+            "cms_playlist_id": 139,
+            "active": True,
+        },
+    )
+    assert connect.status_code == 200
+    payload = connect.json()
+    assert payload["phone"] == "+972500000901"
+    assert payload["meta_user_id"] == "meta-901"
+    assert payload["cms_campaign_id"] == 157
+    assert payload["cms_playlist_id"] == 139
+    assert payload["active"] is True
+
+    by_phone = await admin_client.get(
+        "/admin/operators/by-phone/+972500000901",
+        headers=headers,
+    )
+    assert by_phone.status_code == 200
+    assert by_phone.json()["meta_user_id"] == "meta-901"
+
+    by_meta = await admin_client.get(
+        "/admin/operators/by-meta/meta-901",
+        headers=headers,
+    )
+    assert by_meta.status_code == 200
+    assert by_meta.json()["phone"] == "+972500000901"
+
+
+async def test_admin_can_update_existing_operator_mapping(
+    admin_app,
+    admin_client: AsyncClient,
+) -> None:
+    await _seed_operator(admin_app, phone="+972500000902")
+    headers = _basic_auth_header("admin", "secret")
+
+    first_update = await admin_client.post(
+        "/admin/operators/connect",
+        headers=headers,
+        json={
+            "phone": "+972500000902",
+            "meta_user_id": "meta-902",
+            "cms_campaign_id": 111,
+            "cms_playlist_id": 222,
+            "active": True,
+        },
+    )
+    assert first_update.status_code == 200
+
+    second_update = await admin_client.post(
+        "/admin/operators/connect",
+        headers=headers,
+        json={
+            "phone": "+972500000902",
+            "cms_campaign_id": 333,
+            "cms_playlist_id": 444,
+            "active": False,
+        },
+    )
+    assert second_update.status_code == 200
+    payload = second_update.json()
+    assert payload["meta_user_id"] == "meta-902"
+    assert payload["cms_campaign_id"] == 333
+    assert payload["cms_playlist_id"] == 444
+    assert payload["active"] is False
+
+
+async def test_admin_rejects_missing_identifiers(admin_client: AsyncClient) -> None:
+    headers = _basic_auth_header("admin", "secret")
+    response = await admin_client.post(
+        "/admin/operators/connect",
+        headers=headers,
+        json={
+            "cms_campaign_id": 157,
+            "cms_playlist_id": 139,
+        },
+    )
+
+    assert response.status_code == 422
+
+
+async def test_admin_home_renders_form(admin_client: AsyncClient) -> None:
+    headers = _basic_auth_header("admin", "secret")
+    response = await admin_client.get("/admin", headers=headers)
+
+    assert response.status_code == 200
+    assert "Operator CMS Mapping" in response.text
+    assert "/admin/operators/connect" in response.text

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -37,7 +37,14 @@ def test_alembic_upgrade_creates_phase1_tables(tmp_path: Path, monkeypatch) -> N
     assert "product_brand" in ad_draft_columns
 
     operator_columns = {column["name"] for column in inspector.get_columns("operator")}
-    assert {"business_name", "logo_url", "brand_colors"}.issubset(operator_columns)
+    assert {
+        "business_name",
+        "logo_url",
+        "brand_colors",
+        "meta_user_id",
+        "cms_campaign_id",
+        "cms_playlist_id",
+    }.issubset(operator_columns)
 
     conversation_columns = {
         column["name"] for column in inspector.get_columns("conversation_session")
@@ -71,3 +78,28 @@ def test_alembic_downgrade_removes_product_brand_and_pending_upload(
         column["name"] for column in inspector.get_columns("conversation_session")
     }
     assert "pending_upload_type" not in conversation_columns
+
+
+def test_alembic_downgrade_removes_operator_cms_mapping_columns(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "alembic_phase1_operator_mapping_downgrade.db"
+    database_url = f"sqlite:///{db_path}"
+
+    monkeypatch.delenv("ALEMBIC_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.set_main_option("sqlalchemy.url", database_url)
+
+    command.upgrade(alembic_cfg, "head")
+    command.downgrade(alembic_cfg, "20260304_0004")
+
+    engine = create_engine(database_url)
+    inspector = inspect(engine)
+
+    operator_columns = {column["name"] for column in inspector.get_columns("operator")}
+    assert "meta_user_id" not in operator_columns
+    assert "cms_campaign_id" not in operator_columns
+    assert "cms_playlist_id" not in operator_columns

--- a/tests/test_phase8_cms_publish.py
+++ b/tests/test_phase8_cms_publish.py
@@ -29,6 +29,9 @@ class FakeCMSPublisher:
         self.calls = 0
         self.last_image_url: str | None = None
         self.last_title: str | None = None
+        self.last_campaign_id: int | None = None
+        self.last_playlist_id: int | None = None
+        self.target_calls: list[tuple[int | None, int | None]] = []
         self.raise_error: Exception | None = None
 
     async def publish_generated_image(
@@ -36,10 +39,15 @@ class FakeCMSPublisher:
         *,
         image_url: str,
         title: str,
+        campaign_id: int | None = None,
+        playlist_id: int | None = None,
     ) -> CMSPublishResult:
         self.calls += 1
         self.last_image_url = image_url
         self.last_title = title
+        self.last_campaign_id = campaign_id
+        self.last_playlist_id = playlist_id
+        self.target_calls.append((campaign_id, playlist_id))
         if self.raise_error is not None:
             raise self.raise_error
         return CMSPublishResult(file_id=1280, advertisement_id=975, slot_id=336)
@@ -59,9 +67,21 @@ async def session_factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[As
     await engine.dispose()
 
 
-async def _seed_operator(factory: async_sessionmaker[AsyncSession], phone: str) -> None:
+async def _seed_operator(
+    factory: async_sessionmaker[AsyncSession],
+    phone: str,
+    *,
+    with_mapping: bool = True,
+    campaign_id: int = 157,
+    playlist_id: int = 139,
+) -> None:
     async with session_scope(factory) as session:
-        await OperatorRepository(session).create(phone=phone, active=True)
+        await OperatorRepository(session).create(
+            phone=phone,
+            active=True,
+            cms_campaign_id=campaign_id if with_mapping else None,
+            cms_playlist_id=playlist_id if with_mapping else None,
+        )
 
 
 async def _seed_preview_draft(
@@ -119,6 +139,8 @@ async def test_confirm_publish_button_publishes_to_cms_and_marks_draft_published
     assert cms.calls == 1
     assert cms.last_image_url == "https://storage.googleapis.com/media/preview.png"
     assert cms.last_title == "Milk"
+    assert cms.last_campaign_id == 157
+    assert cms.last_playlist_id == 139
 
     async with session_scope(session_factory) as session:
         updated_draft = await session.get(AdDraft, draft_id)
@@ -162,3 +184,82 @@ async def test_confirm_publish_button_returns_error_message_when_cms_fails(
     assert result.reply_text is not None
     assert "הפרסום נכשל" in result.reply_text or "publishing failed" in result.reply_text.lower()
     assert "cityscreen 400" in result.reply_text
+
+
+async def test_confirm_publish_button_blocks_when_operator_cms_mapping_missing(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    phone = "+972500000803"
+    await _seed_operator(session_factory, phone, with_mapping=False)
+    draft_id = await _seed_preview_draft(
+        session_factory,
+        phone=phone,
+        rendered_image_url="https://storage.googleapis.com/media/preview.png",
+    )
+    cms = FakeCMSPublisher()
+    processor = InboundTaskProcessor(session_factory, cms_publisher=cms)
+
+    payload = InboundTaskPayload(
+        wamid="wamid-phase8-confirm-publish-no-mapping",
+        operator_phone=phone,
+        raw_message={
+            "type": "interactive",
+            "interactive": {"button_reply": {"id": BUTTON_CONFIRM_PUBLISH}},
+        },
+    )
+    result = await processor.process(payload)
+
+    assert result.status == "processed"
+    assert result.deterministic_action == "confirm_publish"
+    assert result.reply_text == "אתה לא מחובר למערכת כרגע, פנה לתמיכה כדי לייצר את החיבור"
+    assert cms.calls == 0
+
+    async with session_scope(session_factory) as session:
+        updated_draft = await session.get(AdDraft, draft_id)
+        assert updated_draft is not None
+        assert updated_draft.status == AdDraftStatus.PREVIEW_READY
+
+
+async def test_confirm_publish_routes_by_operator_cms_mapping(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    phone_a = "+972500000804"
+    phone_b = "+972500000805"
+    await _seed_operator(session_factory, phone_a, campaign_id=157, playlist_id=139)
+    await _seed_operator(session_factory, phone_b, campaign_id=501, playlist_id=808)
+    await _seed_preview_draft(
+        session_factory,
+        phone=phone_a,
+        rendered_image_url="https://storage.googleapis.com/media/preview-a.png",
+    )
+    await _seed_preview_draft(
+        session_factory,
+        phone=phone_b,
+        rendered_image_url="https://storage.googleapis.com/media/preview-b.png",
+    )
+    cms = FakeCMSPublisher()
+    processor = InboundTaskProcessor(session_factory, cms_publisher=cms)
+
+    payload_a = InboundTaskPayload(
+        wamid="wamid-phase8-confirm-publish-route-a",
+        operator_phone=phone_a,
+        raw_message={
+            "type": "interactive",
+            "interactive": {"button_reply": {"id": BUTTON_CONFIRM_PUBLISH}},
+        },
+    )
+    payload_b = InboundTaskPayload(
+        wamid="wamid-phase8-confirm-publish-route-b",
+        operator_phone=phone_b,
+        raw_message={
+            "type": "interactive",
+            "interactive": {"button_reply": {"id": BUTTON_CONFIRM_PUBLISH}},
+        },
+    )
+
+    result_a = await processor.process(payload_a)
+    result_b = await processor.process(payload_b)
+
+    assert result_a.status == "processed"
+    assert result_b.status == "processed"
+    assert cms.target_calls == [(157, 139), (501, 808)]

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -55,6 +55,23 @@ async def test_crud_repositories(db_session: AsyncSession) -> None:
     assert refreshed_operator.logo_url == "https://example.com/logo.png"
     assert refreshed_operator.brand_colors == ["#FF0000", "#00FF00"]
 
+    updated_mapping = await operator_repo.update_cms_mapping(
+        operator.phone,
+        meta_user_id="meta-user-1",
+        cms_campaign_id=157,
+        cms_playlist_id=139,
+    )
+    assert updated_mapping is True
+    refreshed_operator = await operator_repo.get_by_phone(operator.phone)
+    assert refreshed_operator is not None
+    assert refreshed_operator.meta_user_id == "meta-user-1"
+    assert refreshed_operator.cms_campaign_id == 157
+    assert refreshed_operator.cms_playlist_id == 139
+
+    by_meta = await operator_repo.get_by_meta_user_id("meta-user-1")
+    assert by_meta is not None
+    assert by_meta.phone == operator.phone
+
     active_operators = await operator_repo.list_active()
     assert len(active_operators) == 1
 


### PR DESCRIPTION
## Summary
- add per-operator CMS mapping fields on `operator` (`meta_user_id`, `cms_campaign_id`, `cms_playlist_id`)
- route publish target by operator mapping (campaign/playlist override per publish request)
- block publish for unmapped operators with fixed Hebrew message and audit event
- add basic admin auth settings (`ADMIN_BASIC_USERNAME`, `ADMIN_BASIC_PASSWORD`)
- add protected admin API + minimal `/admin` page for mapping create/update/fetch
- update schema compatibility checks for new operator columns
- add project documentation for Stage 1 implementation and local run notes

## Documentation
- add `docs/2026-03-05-stage1-operator-cms-routing.md`
- update `docs/mvp-priority-plan-2026-03-05.md` status
- update `README.md` and `.env.example` with admin auth env vars and behavior

## Tests
- `uv run pytest -q tests/test_migrations.py tests/test_repositories.py tests/test_phase8_cms_publish.py tests/test_admin_mvp.py`
- result: `16 passed`

## Notes
- this PR intentionally excludes unrelated local changes in:
  - `src/adv_assistant/ad_generation.py`
  - `src/adv_assistant/db/session.py`
  - `tests/test_phase7_generation.py`
