### PR TITLE
ci: fix workflow parse failure on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   publish-image:
     runs-on: ubuntu-latest
     needs: lint-test
-    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && secrets.GCP_SA_KEY != '' && vars.STAGING_GCP_PROJECT_ID != '' && vars.PROD_GCP_PROJECT_ID != '' && vars.ARTIFACT_REGISTRY_REGION != '' && vars.ARTIFACT_REGISTRY_REPOSITORY != ''
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && vars.STAGING_GCP_PROJECT_ID != '' && vars.PROD_GCP_PROJECT_ID != '' && vars.ARTIFACT_REGISTRY_REGION != '' && vars.ARTIFACT_REGISTRY_REPOSITORY != ''
     outputs:
       image_digest: ${{ steps.publish.outputs.image_digest }}
       image_tag: ${{ steps.publish.outputs.image_tag }}
@@ -129,7 +129,7 @@ jobs:
   deploy-staging:
     runs-on: ubuntu-latest
     needs: publish-image
-    if: github.ref == 'refs/heads/main' && secrets.GCP_SA_KEY != '' && vars.STAGING_GCP_PROJECT_ID != '' && vars.PROD_GCP_PROJECT_ID != '' && vars.ARTIFACT_REGISTRY_REGION != '' && vars.ARTIFACT_REGISTRY_REPOSITORY != '' && vars.STAGING_GCP_REGION != '' && vars.STAGING_CLOUD_RUN_SERVICE != ''
+    if: github.ref == 'refs/heads/main' && vars.STAGING_GCP_PROJECT_ID != '' && vars.PROD_GCP_PROJECT_ID != '' && vars.ARTIFACT_REGISTRY_REGION != '' && vars.ARTIFACT_REGISTRY_REPOSITORY != '' && vars.STAGING_GCP_REGION != '' && vars.STAGING_CLOUD_RUN_SERVICE != ''
     steps:
       - uses: actions/checkout@v4
 
@@ -165,7 +165,7 @@ jobs:
   deploy-production:
     runs-on: ubuntu-latest
     needs: publish-image
-    if: startsWith(github.ref, 'refs/tags/v') && secrets.GCP_SA_KEY != '' && vars.STAGING_GCP_PROJECT_ID != '' && vars.PROD_GCP_PROJECT_ID != '' && vars.ARTIFACT_REGISTRY_REGION != '' && vars.ARTIFACT_REGISTRY_REPOSITORY != '' && vars.PROD_GCP_REGION != '' && vars.PROD_CLOUD_RUN_SERVICE != ''
+    if: startsWith(github.ref, 'refs/tags/v') && vars.STAGING_GCP_PROJECT_ID != '' && vars.PROD_GCP_PROJECT_ID != '' && vars.ARTIFACT_REGISTRY_REGION != '' && vars.ARTIFACT_REGISTRY_REPOSITORY != '' && vars.PROD_GCP_REGION != '' && vars.PROD_CLOUD_RUN_SERVICE != ''
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Removes invalid use of `secrets` context inside job-level `if` expressions in CI workflow.\n\nGitHub does not allow `secrets` in this context, which caused the entire workflow run to fail before starting jobs.