### PR TITLE
ci: disable staging deploy until DB is provisioned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
   deploy-staging:
     runs-on: ubuntu-latest
     needs: publish-image
-    if: github.ref == 'refs/heads/main' && vars.STAGING_GCP_PROJECT_ID != '' && vars.PROD_GCP_PROJECT_ID != '' && vars.ARTIFACT_REGISTRY_REGION != '' && vars.ARTIFACT_REGISTRY_REPOSITORY != '' && vars.STAGING_GCP_REGION != '' && vars.STAGING_CLOUD_RUN_SERVICE != ''
+    if: github.ref == 'refs/heads/main' && vars.STAGING_DEPLOY_ENABLED == 'true' && vars.STAGING_GCP_PROJECT_ID != '' && vars.PROD_GCP_PROJECT_ID != '' && vars.ARTIFACT_REGISTRY_REGION != '' && vars.ARTIFACT_REGISTRY_REPOSITORY != '' && vars.STAGING_GCP_REGION != '' && vars.STAGING_CLOUD_RUN_SERVICE != ''
     steps:
       - uses: actions/checkout@v4
 
@@ -157,6 +157,7 @@ jobs:
           fi
 
           gcloud run deploy "$STAGING_CLOUD_RUN_SERVICE" \
+            --quiet \
             --project "$STAGING_GCP_PROJECT_ID" \
             --region "$STAGING_GCP_REGION" \
             --image "$IMAGE_REF" \
@@ -193,6 +194,7 @@ jobs:
           fi
 
           gcloud run deploy "$PROD_CLOUD_RUN_SERVICE" \
+            --quiet \
             --project "$PROD_GCP_PROJECT_ID" \
             --region "$PROD_GCP_REGION" \
             --image "$IMAGE_REF" \

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Required repository variables for `main` image publish:
 - `PROD_GCP_PROJECT_ID`
 
 Required repository variables for staging deploy:
+- `STAGING_DEPLOY_ENABLED=true` (set to `false` to skip staging deploy while infra is not ready)
 - `STAGING_GCP_REGION`
 - `STAGING_CLOUD_RUN_SERVICE`
 - optional: `STAGING_CLOUD_RUN_ALLOW_UNAUTHENTICATED=true`


### PR DESCRIPTION
Adds an explicit staging deploy gate variable:\n- deploy-staging runs only when STAGING_DEPLOY_ENABLED=true\n- set repository variable STAGING_DEPLOY_ENABLED=false now\n- add --quiet to gcloud run deploy commands to avoid interactive prompt noise in CI\n- update README variable docs