### PR TITLE
CI: fix smoke-staging worker auth token claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,7 @@ jobs:
 
           TASKS_ID_TOKEN="$(gcloud auth print-identity-token \
             --impersonate-service-account="$STAGING_TASKS_SERVICE_ACCOUNT_EMAIL" \
+            --include-email \
             --audiences="$TASKS_URL")"
           if [ -z "$TASKS_ID_TOKEN" ]; then
             echo "Worker auth smoke failed: could not mint OIDC token for tasks service account." >&2


### PR DESCRIPTION
## What
- add `--include-email` when minting the OIDC token for the `smoke-staging` worker call

## Why
- worker task auth validates the token `email` claim against `TASKS_ALLOWED_SERVICE_ACCOUNT_EMAIL`
- `gcloud auth print-identity-token` without `--include-email` can produce a token missing `email`, causing `401 Unauthorized caller`

## Validation
- YAML parse check passed (`ruby` + `YAML.load_file`)
- previously failing job: `smoke-staging` in run `22818576786` now has the required claim path
