### PR TITLE
SP-04: image-first intake and streamlined publish/regenerate flow

### DIFF
--- a/src/adv_assistant/pipeline.py
+++ b/src/adv_assistant/pipeline.py
@@ -224,6 +224,18 @@ class _CreativeBriefPlannerTurnResult:
     validation_fallback: bool
 
 
+@dataclass(slots=True)
+class _ProductConfirmationPromptResult:
+    draft: AdDraft
+    reply_text: str
+    generated_image_url: str | None
+    action_buttons_prompt: str
+    action_buttons: list[tuple[str, str]]
+    pending_question_type: PendingQuestionType
+    pending_question_context: dict[str, Any]
+    deterministic_action: str
+
+
 def _operator_needs_onboarding(operator: Operator) -> bool:
     """Return True if the operator has not completed first-time onboarding."""
     return operator.business_name is None or operator.logo_url is None
@@ -758,47 +770,10 @@ class InboundTaskProcessor:
                                 current_draft = updated_draft
                                 deterministic_action = "variant_selected"
                                 base_reply = _variant_selected_reply(operator.language, slot_label)
-                                # Check for follow-up questions after selection.
-                                next_q = self._select_next_question(
-                                    current_draft=current_draft,
-                                    operator=operator,
-                                    after_preview_generation=True,
-                                    allow_regenerate_confirmation=True,
-                                    current_pending_question_context=pending_question_context,
-                                )
-                                if next_q is not None:
-                                    pending_question_type = next_q.pending_question_type
-                                    pending_question_context = next_q.pending_question_context
-                                    if (
-                                        next_q.pending_question_type
-                                        == PendingQuestionType.MISSING_INFO
-                                    ):
-                                        # Keep missing-info clarifications separate. For missing
-                                        # price specifically, defer publish actions until the
-                                        # operator provides the price.
-                                        reply_text = next_q.prompt_text
-                                        next_question_key = question_policy.pending_question_key(
-                                            pending_question_type=next_q.pending_question_type,
-                                            pending_question_context=next_q.pending_question_context,
-                                        )
-                                        if next_question_key == question_policy.QUESTION_KEY_PRICE:
-                                            publish_buttons_prompt = None
-                                        else:
-                                            publish_buttons_prompt = _publish_buttons_prompt(
-                                                operator.language
-                                            )
-                                    else:
-                                        reply_text = f"{base_reply}\n\n{next_q.prompt_text}"
-                                        publish_buttons_prompt = _publish_buttons_prompt(
-                                            operator.language
-                                        )
-                                else:
-                                    pending_question_type = PendingQuestionType.NONE
-                                    pending_question_context = {}
-                                    reply_text = base_reply
-                                    publish_buttons_prompt = _publish_buttons_prompt(
-                                        operator.language
-                                    )
+                                pending_question_type = PendingQuestionType.NONE
+                                pending_question_context = {}
+                                reply_text = base_reply
+                                publish_buttons_prompt = _publish_buttons_prompt(operator.language)
                                 await audit_repo.log(
                                     actor="system",
                                     action="variant_selected",
@@ -824,7 +799,11 @@ class InboundTaskProcessor:
                 elif button_payload_id == BUTTON_CONFIRM_PUBLISH:
                     deterministic_action = "confirm_publish"
                     intent_value = deterministic_action
-                    current_draft, reply_text = await self._confirm_publish_to_cms(
+                    (
+                        current_draft,
+                        reply_text,
+                        publish_resolved,
+                    ) = await self._confirm_publish_to_cms(
                         payload=payload,
                         draft_repo=draft_repo,
                         published_repo=published_repo,
@@ -833,6 +812,61 @@ class InboundTaskProcessor:
                         current_draft=current_draft,
                         language=operator.language,
                     )
+                    if publish_resolved:
+                        previous_draft_id = current_draft.id
+                        current_draft = await draft_repo.create(
+                            operator_phone=payload.operator_phone,
+                            status=AdDraftStatus.DRAFT,
+                            currency=operator.currency,
+                        )
+                        draft_created = True
+                        pending_question_type = PendingQuestionType.NONE
+                        pending_question_context = {}
+                        publish_buttons_prompt = None
+                        action_buttons_prompt = None
+                        action_buttons = None
+                        await audit_repo.log(
+                            actor="system",
+                            action="draft_reset_after_publish_decision",
+                            operator_phone=payload.operator_phone,
+                            metadata={
+                                "wamid": payload.wamid,
+                                "decision": "apply",
+                                "previous_draft_id": str(previous_draft_id),
+                                "new_draft_id": str(current_draft.id),
+                            },
+                        )
+                elif button_payload_id == BUTTON_CANCEL_PUBLISH:
+                    deterministic_action = "cancel_publish"
+                    intent_value = deterministic_action
+                    reply_text = _publish_canceled_reply(operator.language)
+                    if current_draft.rendered_image_url is not None or current_draft.status in {
+                        AdDraftStatus.PREVIEW_READY,
+                        AdDraftStatus.PUBLISHED,
+                    }:
+                        previous_draft_id = current_draft.id
+                        current_draft = await draft_repo.create(
+                            operator_phone=payload.operator_phone,
+                            status=AdDraftStatus.DRAFT,
+                            currency=operator.currency,
+                        )
+                        draft_created = True
+                        pending_question_type = PendingQuestionType.NONE
+                        pending_question_context = {}
+                        publish_buttons_prompt = None
+                        action_buttons_prompt = None
+                        action_buttons = None
+                        await audit_repo.log(
+                            actor="system",
+                            action="draft_reset_after_publish_decision",
+                            operator_phone=payload.operator_phone,
+                            metadata={
+                                "wamid": payload.wamid,
+                                "decision": "cancel",
+                                "previous_draft_id": str(previous_draft_id),
+                                "new_draft_id": str(current_draft.id),
+                            },
+                        )
                 else:
                     deterministic_action, reply_text = _resolve_button_action(button_payload_id)
                     intent_value = deterministic_action
@@ -850,11 +884,7 @@ class InboundTaskProcessor:
                         "wamid": payload.wamid,
                     }
                 )
-                if pending_question_type == PendingQuestionType.CLASSIFICATION:
-                    reply_text = _classification_prompt(operator.language)
-                    deterministic_action = "classification_reprompt"
-                    intent_value = last_user_intent_hint
-                elif pending_upload_type == _PENDING_UPLOAD_LOGO:
+                if pending_upload_type == _PENDING_UPLOAD_LOGO:
                     deterministic_action = "operator_logo_upload"
                     intent_value = deterministic_action
                     reply_text = await self._process_logo_upload(
@@ -865,8 +895,27 @@ class InboundTaskProcessor:
                         media_id=incoming_image_media_id,
                     )
                 else:
+                    can_start_fresh_image_flow = (
+                        pending_question_type == PendingQuestionType.NONE
+                        and current_draft.status == AdDraftStatus.DRAFT
+                        and not current_draft.awaiting_product_confirmation
+                        and current_draft.photo_url is None
+                        and current_draft.rendered_image_url is None
+                        and current_draft.preview_reference_url is None
+                    )
+                    is_image_first_path = (
+                        pending_question_type == PendingQuestionType.CLASSIFICATION
+                        or current_draft.request_type == AdRequestType.UNSET
+                        or can_start_fresh_image_flow
+                    )
                     deterministic_action = "operator_photo_ingest"
-                    intent_value = deterministic_action
+                    if is_image_first_path:
+                        intent_value = Intent.CREATE_AD.value
+                    else:
+                        intent_value = deterministic_action
+                    previous_pending_question_type = pending_question_type
+                    previous_pending_question_context = dict(pending_question_context)
+                    previous_photo_url = current_draft.photo_url
                     current_draft, reply_text = await self._process_operator_photo_message(
                         payload=payload,
                         draft_repo=draft_repo,
@@ -875,6 +924,53 @@ class InboundTaskProcessor:
                         language=operator.language,
                         media_id=incoming_image_media_id,
                     )
+                    photo_ingested = current_draft.photo_url is not None and (
+                        previous_photo_url is None or current_draft.photo_url != previous_photo_url
+                    )
+                    if is_image_first_path and photo_ingested:
+                        updated_draft = await draft_repo.update_for_operator_with_version(
+                            draft_id=current_draft.id,
+                            operator_phone=payload.operator_phone,
+                            expected_version=current_draft.version,
+                            request_type=AdRequestType.SINGLE_PRODUCT,
+                            classification_status=ClassificationStatus.RESOLVED,
+                            is_classification_resolved=True,
+                            awaiting_product_confirmation=True,
+                        )
+                        if updated_draft is None:
+                            reply_text = (
+                                "This draft was already changed. Please refresh and try again."
+                            )
+                            await audit_repo.log(
+                                actor="system",
+                                action="draft_stale_write_detected",
+                                operator_phone=payload.operator_phone,
+                                metadata={"wamid": payload.wamid},
+                            )
+                            pending_question_type = previous_pending_question_type
+                            pending_question_context = previous_pending_question_context
+                        else:
+                            current_draft = updated_draft
+                            confirmation_prompt = (
+                                await self._build_product_confirmation_requested_response(
+                                    payload=payload,
+                                    draft_repo=draft_repo,
+                                    audit_repo=audit_repo,
+                                    current_draft=current_draft,
+                                    language=operator.language,
+                                )
+                            )
+                            current_draft = confirmation_prompt.draft
+                            deterministic_action = confirmation_prompt.deterministic_action
+                            generated_image_url = confirmation_prompt.generated_image_url
+                            reply_text = confirmation_prompt.reply_text
+                            action_buttons_prompt = confirmation_prompt.action_buttons_prompt
+                            action_buttons = confirmation_prompt.action_buttons
+                            pending_question_type = confirmation_prompt.pending_question_type
+                            pending_question_context = confirmation_prompt.pending_question_context
+                    elif is_image_first_path:
+                        pending_question_type = previous_pending_question_type
+                        pending_question_context = previous_pending_question_context
                 # Upload intent is one-shot; consume it after the first image.
                 if pending_question_type != PendingQuestionType.CLASSIFICATION:
                     pending_upload_type = None
@@ -1164,12 +1260,12 @@ class InboundTaskProcessor:
                                 transition_status = question_policy.PendingResolutionStatus.RESOLVED
                                 pending_handled = True
                             elif yes_no is False:
-                                reply_text = _regenerate_again_declined_reply(operator.language)
+                                transition_status = question_policy.PendingResolutionStatus.RESOLVED
                                 if current_draft.rendered_image_url is not None:
+                                    reply_text = _publish_confirmation_prompt(operator.language)
                                     publish_buttons_prompt = _publish_buttons_prompt(
                                         operator.language
                                     )
-                                transition_status = question_policy.PendingResolutionStatus.RESOLVED
                                 pending_handled = True
                             else:
                                 classification = await self._llm_gateway.classify_intent(
@@ -1183,9 +1279,6 @@ class InboundTaskProcessor:
                                     and not _is_explicit_new_ad_interrupt(sanitized_text)
                                     and not _is_likely_create_ad_request(sanitized_text)
                                 ):
-                                    # In the "regenerate again?" follow-up, free-text feedback
-                                    # should continue the current draft instead of starting a
-                                    # brand-new ad flow.
                                     followup_regen_requested = True
                                     forced_intent = Intent.REGENERATE_WITH_REFERENCE
                                     transition_status = (
@@ -1200,9 +1293,14 @@ class InboundTaskProcessor:
                                     )
                                 else:
                                     transition_status = (
-                                        question_policy.PendingResolutionStatus.UNRESOLVED
+                                        question_policy.PendingResolutionStatus.RESOLVED
                                     )
                                     classification = IntentClassification(intent=Intent.UNKNOWN)
+                                    if current_draft.rendered_image_url is not None:
+                                        reply_text = _publish_confirmation_prompt(operator.language)
+                                        publish_buttons_prompt = _publish_buttons_prompt(
+                                            operator.language
+                                        )
                                 pending_handled = True
                         elif pending_question_type == PendingQuestionType.MISSING_INFO:
                             (
@@ -1269,25 +1367,10 @@ class InboundTaskProcessor:
                                     phase == question_policy.QUESTION_PHASE_PRE_GENERATION
                                 )
                                 if is_post_preview_phase:
-                                    next_question = self._select_next_question(
-                                        current_draft=current_draft,
-                                        operator=operator,
-                                        after_preview_generation=True,
-                                        allow_regenerate_confirmation=True,
-                                        current_pending_question_context=pending_question_context,
-                                    )
-                                    if (
-                                        pending_question_type == PendingQuestionType.MISSING_INFO
-                                        and pending_question_key
-                                        == question_policy.QUESTION_KEY_PRICE
-                                        and next_question is not None
-                                        and next_question.pending_question_type
-                                        == PendingQuestionType.GENERATION_RETRY
-                                    ):
-                                        # After a missing-price answer is resolved, surface
-                                        # publish confirmation directly.
-                                        next_question = None
-                                        forced_intent = Intent.PUBLISH_AD
+                                    # Post-preview followups now end with publish confirmation,
+                                    # without another "regenerate again?" question.
+                                    next_question = None
+                                    forced_intent = Intent.PUBLISH_AD
                                 elif is_pre_generation_phase:
                                     next_question = self._select_next_question(
                                         current_draft=current_draft,
@@ -1335,9 +1418,19 @@ class InboundTaskProcessor:
                     elif classification is None:
                         classification = IntentClassification(intent=Intent.UNKNOWN)
 
+                    has_selected_preview_context = (
+                        pending_question_type == PendingQuestionType.NONE
+                        and current_draft.selected_variant_id is not None
+                        and current_draft.rendered_image_url is not None
+                        and current_draft.status
+                        in {AdDraftStatus.PREVIEW_READY, AdDraftStatus.PUBLISHED}
+                    )
                     if (
-                        pending_question_type == PendingQuestionType.VARIANT_SELECTION
-                        and classification.intent == Intent.CREATE_AD
+                        classification.intent == Intent.CREATE_AD
+                        and (
+                            pending_question_type == PendingQuestionType.VARIANT_SELECTION
+                            or has_selected_preview_context
+                        )
                         and not _is_explicit_new_ad_interrupt(sanitized_text)
                         and not _is_likely_create_ad_request(sanitized_text)
                     ):
@@ -1504,45 +1597,6 @@ class InboundTaskProcessor:
                                 message_text=classification_context_text,
                                 reply_text=reply_text,
                             )
-                            if followup_regen_requested:
-                                branding = await self._llm_gateway.extract_branding_fields(
-                                    message_text=sanitized_text,
-                                    language=operator.language,
-                                )
-                                llm_used = self._llm_gateway.uses_external_llm or llm_used
-                                branding_update_fields = branding.to_update_kwargs()
-                                if branding_update_fields:
-                                    await operator_repo.update_branding(
-                                        payload.operator_phone,
-                                        **branding_update_fields,
-                                    )
-                                    if "language" in branding_update_fields:
-                                        operator.language = str(branding_update_fields["language"])
-                                        session_language_override = operator.language
-                                    if "store_type" in branding_update_fields:
-                                        operator.store_type = branding_update_fields["store_type"]
-                                    if "creative_guidance" in branding_update_fields:
-                                        operator.creative_guidance = branding_update_fields[
-                                            "creative_guidance"
-                                        ]
-                                    if "business_name" in branding_update_fields:
-                                        operator.business_name = branding_update_fields[
-                                            "business_name"
-                                        ]
-                                    if "brand_colors" in branding_update_fields:
-                                        operator.brand_colors = branding_update_fields[
-                                            "brand_colors"
-                                        ]
-                                    await audit_repo.log(
-                                        actor="system",
-                                        action="operator_branding_updated",
-                                        operator_phone=payload.operator_phone,
-                                        metadata={
-                                            "wamid": payload.wamid,
-                                            "updated_fields": sorted(branding_update_fields.keys()),
-                                            "source": "followup_regenerate_confirmation",
-                                        },
-                                    )
                             current_draft, enrichment_notice = await self._enrich_current_draft(
                                 payload=payload,
                                 draft_repo=draft_repo,
@@ -1592,61 +1646,24 @@ class InboundTaskProcessor:
                                 and current_draft.awaiting_product_confirmation
                                 and current_draft.photo_url is not None
                             ):
-                                (
-                                    current_draft,
-                                    confirmation_image_url,
-                                ) = await self._prepare_product_confirmation_image(
-                                    payload=payload,
-                                    draft_repo=draft_repo,
-                                    audit_repo=audit_repo,
-                                    current_draft=current_draft,
-                                )
-                                deterministic_action = "product_confirmation_requested"
-                                generated_image_url = confirmation_image_url
-                                reply_text = _product_confirmation_caption(
-                                    language=operator.language,
-                                    product_name=current_draft.product_name,
-                                )
-                                if (
-                                    generated_image_url is None
-                                    and current_draft.photo_url is not None
-                                ):
-                                    reply_text = (
-                                        f"{reply_text}\n\n"
-                                        + _product_confirmation_image_link_fallback_reply(
-                                            language=operator.language,
-                                            image_url=current_draft.photo_url,
-                                        )
+                                confirmation_prompt = (
+                                    await self._build_product_confirmation_requested_response(
+                                        payload=payload,
+                                        draft_repo=draft_repo,
+                                        audit_repo=audit_repo,
+                                        current_draft=current_draft,
+                                        language=operator.language,
                                     )
-                                action_buttons_prompt = _product_confirmation_buttons_prompt(
-                                    operator.language
                                 )
-                                action_buttons = [
-                                    (
-                                        BUTTON_CONFIRM_PRODUCT_SELECTION,
-                                        _product_confirmation_accept_label(operator.language),
-                                    ),
-                                    (
-                                        BUTTON_REJECT_PRODUCT_SELECTION,
-                                        _product_confirmation_reject_label(operator.language),
-                                    ),
-                                ]
-                                pending_question_type = PendingQuestionType.PRODUCT_CONFIRMATION
-                                pending_question_context = {
-                                    "draft_id": str(current_draft.id),
-                                    "photo_url": current_draft.photo_url,
-                                    "product_name": current_draft.product_name,
-                                }
-                                await audit_repo.log(
-                                    actor="system",
-                                    action="product_confirmation_requested",
-                                    operator_phone=payload.operator_phone,
-                                    metadata={
-                                        "wamid": payload.wamid,
-                                        "draft_id": str(current_draft.id),
-                                        "photo_url": current_draft.photo_url,
-                                        "product_name": current_draft.product_name,
-                                    },
+                                current_draft = confirmation_prompt.draft
+                                deterministic_action = confirmation_prompt.deterministic_action
+                                generated_image_url = confirmation_prompt.generated_image_url
+                                reply_text = confirmation_prompt.reply_text
+                                action_buttons_prompt = confirmation_prompt.action_buttons_prompt
+                                action_buttons = confirmation_prompt.action_buttons
+                                pending_question_type = confirmation_prompt.pending_question_type
+                                pending_question_context = (
+                                    confirmation_prompt.pending_question_context
                                 )
                     elif classification.intent == Intent.UNKNOWN and detected_ean is not None:
                         current_draft, enrichment_notice = await self._enrich_current_draft(
@@ -2172,11 +2189,11 @@ class InboundTaskProcessor:
         operator: Operator,
         current_draft: AdDraft,
         language: str,
-    ) -> tuple[AdDraft, str]:
+    ) -> tuple[AdDraft, str, bool]:
         if current_draft.rendered_image_url is None:
             if language.lower() == "he":
-                return current_draft, "אין כרגע תמונת תצוגה מוכנה לפרסום."
-            return current_draft, "There is no generated preview image ready for publishing."
+                return current_draft, "אין כרגע תמונת תצוגה מוכנה לפרסום.", False
+            return current_draft, "There is no generated preview image ready for publishing.", False
 
         # Idempotency: skip CMS call if draft is already published.
         if current_draft.status == AdDraftStatus.PUBLISHED:
@@ -2193,8 +2210,8 @@ class InboundTaskProcessor:
                     },
                 )
                 if language.lower() == "he":
-                    return current_draft, "המודעה הזו כבר פורסמה."
-                return current_draft, "This ad has already been published."
+                    return current_draft, "המודעה הזו כבר פורסמה.", True
+                return current_draft, "This ad has already been published.", True
 
         campaign_id = _coerce_positive_int(operator.cms_campaign_id)
         playlist_id = _coerce_positive_int(operator.cms_playlist_id)
@@ -2210,12 +2227,12 @@ class InboundTaskProcessor:
                     "cms_playlist_id": operator.cms_playlist_id,
                 },
             )
-            return current_draft, _cms_not_connected_reply()
+            return current_draft, _cms_not_connected_reply(), False
 
         if not self._cms_publisher.enabled:
             if language.lower() == "he":
-                return current_draft, "הפרסום ל-CMS לא מוגדר כרגע במערכת."
-            return current_draft, "CMS publishing is not configured yet."
+                return current_draft, "הפרסום ל-CMS לא מוגדר כרגע במערכת.", False
+            return current_draft, "CMS publishing is not configured yet.", False
 
         title = current_draft.product_name or f"draft-{current_draft.id}"
         logger.info(
@@ -2283,8 +2300,8 @@ class InboundTaskProcessor:
                 flush=True,
             )
             if language.lower() == "he":
-                return current_draft, "הפרסום הצליח. המודעה נוספה לפלייליסט."
-            return current_draft, "Publishing succeeded. Your ad was added to the playlist."
+                return current_draft, "הפרסום הצליח. המודעה נוספה לפלייליסט.", True
+            return current_draft, "Publishing succeeded. Your ad was added to the playlist.", True
         except CMSPublishError as exc:
             await audit_repo.log(
                 actor="system",
@@ -2307,8 +2324,8 @@ class InboundTaskProcessor:
                 flush=True,
             )
             if language.lower() == "he":
-                return current_draft, f"הפרסום נכשל: {exc}"
-            return current_draft, f"Publishing failed: {exc}"
+                return current_draft, f"הפרסום נכשל: {exc}", False
+            return current_draft, f"Publishing failed: {exc}", False
 
     async def _process_operator_photo_message(
         self,
@@ -3598,6 +3615,67 @@ class InboundTaskProcessor:
         )
         return current_draft, ingested_photo.public_url
 
+    async def _build_product_confirmation_requested_response(
+        self,
+        *,
+        payload: InboundTaskPayload,
+        draft_repo: AdDraftRepository,
+        audit_repo: AuditEventRepository,
+        current_draft: AdDraft,
+        language: str,
+    ) -> _ProductConfirmationPromptResult:
+        current_draft, confirmation_image_url = await self._prepare_product_confirmation_image(
+            payload=payload,
+            draft_repo=draft_repo,
+            audit_repo=audit_repo,
+            current_draft=current_draft,
+        )
+        reply_text = _product_confirmation_caption(
+            language=language,
+            product_name=current_draft.product_name,
+        )
+        if confirmation_image_url is None and current_draft.photo_url is not None:
+            reply_text = f"{reply_text}\n\n" + _product_confirmation_image_link_fallback_reply(
+                language=language,
+                image_url=current_draft.photo_url,
+            )
+        action_buttons = [
+            (
+                BUTTON_CONFIRM_PRODUCT_SELECTION,
+                _product_confirmation_accept_label(language),
+            ),
+            (
+                BUTTON_REJECT_PRODUCT_SELECTION,
+                _product_confirmation_reject_label(language),
+            ),
+        ]
+        pending_question_context = {
+            "draft_id": str(current_draft.id),
+            "photo_url": current_draft.photo_url,
+            "product_name": current_draft.product_name,
+        }
+        await audit_repo.log(
+            actor="system",
+            action="product_confirmation_requested",
+            operator_phone=payload.operator_phone,
+            metadata={
+                "wamid": payload.wamid,
+                "draft_id": str(current_draft.id),
+                "photo_url": current_draft.photo_url,
+                "product_name": current_draft.product_name,
+            },
+        )
+        return _ProductConfirmationPromptResult(
+            draft=current_draft,
+            reply_text=reply_text,
+            generated_image_url=confirmation_image_url,
+            action_buttons_prompt=_product_confirmation_buttons_prompt(language),
+            action_buttons=action_buttons,
+            pending_question_type=PendingQuestionType.PRODUCT_CONFIRMATION,
+            pending_question_context=pending_question_context,
+            deterministic_action="product_confirmation_requested",
+        )
+
     async def _enrich_current_draft(
         self,
         *,
@@ -4270,8 +4348,11 @@ def _missing_product_name_reply(language: str) -> str:
 
 def _publish_confirmation_prompt(language: str) -> str:
     if language.lower() == "he":
-        return "בחר האם לפרסם עכשיו ל-CMS או לבטל."
-    return "Choose whether to publish to CMS now or cancel."
+        return "תרצה לפרסם את הגרסא שבחרת?\n(במידה ויש שינויים נוספים תכתוב אותם כאן)"
+    return (
+        "Would you like to publish the selected version?\n"
+        "(If there are more changes, write them here.)"
+    )
 
 
 def _is_confirmation_image_url_compatible(image_url: str) -> bool:
@@ -4352,8 +4433,11 @@ def _product_confirmation_generation_instruction(language: str) -> str:
 
 def _publish_buttons_prompt(language: str) -> str:
     if language.lower() == "he":
-        return "לפרסם את המודעה הזו ל-CMS?"
-    return "Publish this ad to CMS?"
+        return "תרצה לפרסם את הגרסא שבחרת?\n(במידה ויש שינויים נוספים תכתוב אותם כאן)"
+    return (
+        "Would you like to publish the selected version?\n"
+        "(If there are more changes, write them here.)"
+    )
 
 
 def _variant_selection_prompt(language: str) -> str:
@@ -4378,8 +4462,14 @@ def _variant_selection_buttons(
 
 def _variant_selected_reply(language: str, slot_label: str) -> str:
     if language.lower() == "he":
-        return f"גרסה {slot_label} נבחרה. תרצה לפרסם את המודעה?"
-    return f"Variant {slot_label} selected. Would you like to publish this ad?"
+        return f"גרסה {slot_label} נבחרה."
+    return f"Variant {slot_label} selected."
+
+
+def _publish_canceled_reply(language: str) -> str:
+    if language.lower() == "he":
+        return "המודעה לא פורסמה. אפסתי את הטיוטה ואפשר להתחיל מודעה חדשה מתי שתרצה."
+    return "The ad was not published. I reset the draft and you can start a new ad anytime."
 
 
 def _variant_selection_use_buttons_reply(language: str) -> str:

--- a/src/adv_assistant/question_policy.py
+++ b/src/adv_assistant/question_policy.py
@@ -446,9 +446,10 @@ def reprompt_limit_message(language: str) -> str:
 
 def regenerate_again_prompt(language: str) -> str:
     if language.lower() == "he":
-        return "כל השאלות הושלמו. רוצה שאפעיל עכשיו יצירת מודעה נוספת? (כן/לא)"
+        return "תרצה לפרסם את הגרסא שבחרת?\n(במידה ויש שינויים נוספים תכתוב אותם כאן)"
     return (
-        "All follow-up questions are complete. Do you want me to generate another ad now? (yes/no)"
+        "Would you like to publish the selected version?\n"
+        "(If there are more changes, write them here.)"
     )
 
 

--- a/tests/test_conversation_flow_v1_e2e.py
+++ b/tests/test_conversation_flow_v1_e2e.py
@@ -4,7 +4,7 @@ Covers:
 - Full flow: create ad → generate → select variant → publish
 - Already-enough-info → direct generation path
 - Interrupt: new CREATE_AD during variant selection
-- Idempotent publish re-press
+- Publish action resets the active draft
 """
 
 from collections.abc import AsyncIterator
@@ -25,12 +25,19 @@ from adv_assistant.ad_generation import (
 )
 from adv_assistant.cms_cityscreen import CMSPublishResult
 from adv_assistant.db.base import Base
-from adv_assistant.db.enums import AdDraftStatus
-from adv_assistant.db.models import AdDraft, PublishedAd
+from adv_assistant.db.enums import (
+    AdDraftStatus,
+    AdRequestType,
+    ClassificationStatus,
+    PendingQuestionType,
+)
+from adv_assistant.db.models import AdDraft, ConversationSession, PublishedAd
 from adv_assistant.db.repositories import OperatorRepository
 from adv_assistant.db.session import create_engine, create_session_factory, session_scope
 from adv_assistant.llm_gateway import (
+    BUTTON_CONFIRM_PRODUCT_SELECTION,
     BUTTON_CONFIRM_PUBLISH,
+    BUTTON_REJECT_PRODUCT_SELECTION,
     BUTTON_SELECT_VARIANT_A,
     BUTTON_SELECT_VARIANT_B,
     ExtractedAdFields,
@@ -40,6 +47,7 @@ from adv_assistant.llm_gateway import (
     IntentClassification,
     ReplyGeneration,
 )
+from adv_assistant.media_ingest import IngestedOperatorPhoto
 from adv_assistant.pipeline import InboundTaskProcessor
 from adv_assistant.tasks_queue import InboundTaskPayload
 
@@ -214,6 +222,27 @@ class FakeCMSPublisher:
         return None
 
 
+class StaticPhotoIngestor:
+    async def ingest_whatsapp_image(self, *, media_id: str) -> IngestedOperatorPhoto:
+        return IngestedOperatorPhoto(
+            public_url="https://storage.googleapis.com/media/image-first-e2e.jpg",
+            object_name="operator-photos/image-first-e2e.jpg",
+            content_type="image/jpeg",
+            content=b"jpeg-bytes",
+        )
+
+    async def ingest_external_image_url(self, *, image_url: str) -> IngestedOperatorPhoto:
+        return IngestedOperatorPhoto(
+            public_url="https://storage.googleapis.com/media/image-first-e2e-rehost.jpg",
+            object_name="operator-photos/image-first-e2e-rehost.jpg",
+            content_type="image/jpeg",
+            content=b"jpeg-bytes",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
 # ── Fixtures ───────────────────────────────────────────────────────────
 
 
@@ -330,24 +359,45 @@ async def test_full_v1_flow_create_generate_select_publish(
     assert publish_result.deterministic_action == "confirm_publish"
     assert cms.calls == 1
 
-    # Verify DB state.
+    # Verify DB state: published draft is kept and a fresh draft becomes active.
     async with session_scope(session_factory) as session:
-        draft = (
+        drafts = (
             (await session.execute(select(AdDraft).where(AdDraft.operator_phone == phone)))
             .scalars()
-            .first()
+            .all()
         )
-        assert draft is not None
-        assert draft.status == AdDraftStatus.PUBLISHED
-        assert draft.selected_variant_id is not None
-        assert draft.selected_round_id is not None
+        assert len(drafts) == 2
+        published_draft = next((d for d in drafts if d.status == AdDraftStatus.PUBLISHED), None)
+        assert published_draft is not None
+        assert published_draft.selected_variant_id is not None
+        assert published_draft.selected_round_id is not None
 
         published = (
-            (await session.execute(select(PublishedAd).where(PublishedAd.ad_draft_id == draft.id)))
+            (
+                await session.execute(
+                    select(PublishedAd).where(PublishedAd.ad_draft_id == published_draft.id)
+                )
+            )
             .scalars()
             .first()
         )
         assert published is not None
+
+        session_obj = (
+            (
+                await session.execute(
+                    select(ConversationSession).where(ConversationSession.operator_phone == phone)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert session_obj is not None
+        assert session_obj.current_draft_id is not None
+        active_draft = await session.get(AdDraft, session_obj.current_draft_id)
+        assert active_draft is not None
+        assert active_draft.status == AdDraftStatus.DRAFT
+        assert active_draft.product_name is None
 
 
 async def test_already_enough_info_generates_directly(
@@ -391,6 +441,61 @@ async def test_already_enough_info_generates_directly(
     assert len(result.variant_image_urls) == 2
     assert result.action_buttons is not None  # variant selection
     assert len(generation.submitted_drafts) == 2  # 2 variant slots
+
+
+async def test_image_first_message_enters_product_confirmation_flow(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    phone = "+972500000906"
+    await _seed_operator(session_factory, phone)
+
+    processor = InboundTaskProcessor(
+        session_factory,
+        llm_gateway=SequencedGateway(intents=[]),
+        operator_photo_ingestor=StaticPhotoIngestor(),
+    )
+
+    result = await processor.process(
+        InboundTaskPayload(
+            wamid="wamid-e2e-image-first",
+            operator_phone=phone,
+            raw_message={"type": "image", "image": {"id": "media-image-first"}},
+        )
+    )
+
+    assert result.deterministic_action == "product_confirmation_requested"
+    assert result.generated_image_url == "https://storage.googleapis.com/media/image-first-e2e.jpg"
+    assert result.publish_buttons_prompt is None
+    assert result.action_buttons_prompt is not None
+    assert result.action_buttons == [
+        (BUTTON_CONFIRM_PRODUCT_SELECTION, "כן, זה המוצר"),
+        (BUTTON_REJECT_PRODUCT_SELECTION, "לא, מוצר אחר"),
+    ]
+
+    async with session_scope(session_factory) as session:
+        draft = (
+            (await session.execute(select(AdDraft).where(AdDraft.operator_phone == phone)))
+            .scalars()
+            .first()
+        )
+        assert draft is not None
+        assert draft.photo_url == "https://storage.googleapis.com/media/image-first-e2e.jpg"
+        assert draft.request_type == AdRequestType.SINGLE_PRODUCT
+        assert draft.classification_status == ClassificationStatus.RESOLVED
+        assert draft.is_classification_resolved is True
+        assert draft.awaiting_product_confirmation is True
+
+        session_obj = (
+            (
+                await session.execute(
+                    select(ConversationSession).where(ConversationSession.operator_phone == phone)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert session_obj is not None
+        assert session_obj.pending_question_type == PendingQuestionType.PRODUCT_CONFIRMATION
 
 
 async def test_select_variant_b_sets_correct_variant(

--- a/tests/test_conversation_flow_v1_t5.py
+++ b/tests/test_conversation_flow_v1_t5.py
@@ -16,6 +16,7 @@ from adv_assistant.llm_gateway import (
     IntentClassification,
     ReplyGeneration,
 )
+from adv_assistant.media_ingest import IngestedOperatorPhoto
 from adv_assistant.pipeline import InboundTaskProcessor
 from adv_assistant.product_resolution_models import ProductResolutionResult
 from adv_assistant.tasks_queue import InboundTaskPayload
@@ -100,6 +101,27 @@ class ProductResolutionProbeService:
             product_query=message_text,
             raw_user_text=message_text,
             clarification_question="מה שם המוצר המדויק?",
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+class StaticPhotoIngestor:
+    async def ingest_whatsapp_image(self, *, media_id: str) -> IngestedOperatorPhoto:
+        return IngestedOperatorPhoto(
+            public_url="https://storage.googleapis.com/test-media/operator-photos/t5.jpg",
+            object_name="operator-photos/t5.jpg",
+            content_type="image/jpeg",
+            content=b"jpeg-bytes",
+        )
+
+    async def ingest_external_image_url(self, *, image_url: str) -> IngestedOperatorPhoto:
+        return IngestedOperatorPhoto(
+            public_url="https://storage.googleapis.com/test-media/operator-photos/t5-rehost.jpg",
+            object_name="operator-photos/t5-rehost.jpg",
+            content_type="image/jpeg",
+            content=b"jpeg-bytes",
         )
 
     async def close(self) -> None:
@@ -206,7 +228,7 @@ async def test_classification_followup_resolves_single_product_and_clears_pendin
         assert draft.product_name == "Milk"
 
 
-async def test_non_text_reply_during_classification_is_reprompted_without_photo_ingest(
+async def test_image_reply_during_classification_enters_image_first_product_confirmation(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     phone = "+972500001002"
@@ -215,7 +237,11 @@ async def test_non_text_reply_during_classification_is_reprompted_without_photo_
         intents=[Intent.CREATE_AD],
         ad_fields=[ExtractedAdFields()],
     )
-    processor = InboundTaskProcessor(session_factory, llm_gateway=gateway)
+    processor = InboundTaskProcessor(
+        session_factory,
+        llm_gateway=gateway,
+        operator_photo_ingestor=StaticPhotoIngestor(),
+    )
 
     await processor.process(
         InboundTaskPayload(
@@ -234,16 +260,24 @@ async def test_non_text_reply_during_classification_is_reprompted_without_photo_
     )
 
     assert result.reply_text is not None
-    assert "מוצר אחד" in result.reply_text
-    assert result.deterministic_action == "classification_reprompt"
+    assert "זה המוצר שהתכוונת אליו" in result.reply_text
+    assert result.deterministic_action == "product_confirmation_requested"
+    assert result.generated_image_url == (
+        "https://storage.googleapis.com/test-media/operator-photos/t5.jpg"
+    )
+    assert result.action_buttons is not None
 
     async with session_scope(session_factory) as session:
         session_obj = await ConversationSessionRepository(session).get_by_operator_phone(phone)
         assert session_obj is not None
-        assert session_obj.pending_question_type == PendingQuestionType.CLASSIFICATION
+        assert session_obj.pending_question_type == PendingQuestionType.PRODUCT_CONFIRMATION
         draft = session_obj.current_draft
         assert draft is not None
-        assert draft.photo_url is None
+        assert draft.photo_url == "https://storage.googleapis.com/test-media/operator-photos/t5.jpg"
+        assert draft.request_type == AdRequestType.SINGLE_PRODUCT
+        assert draft.classification_status == ClassificationStatus.RESOLVED
+        assert draft.is_classification_resolved is True
+        assert draft.awaiting_product_confirmation is True
 
 
 async def test_classification_followup_preserves_original_product_request_for_resolution(

--- a/tests/test_phase6_media.py
+++ b/tests/test_phase6_media.py
@@ -6,8 +6,18 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from adv_assistant.db.base import Base
+from adv_assistant.db.enums import (
+    AdDraftStatus,
+    AdRequestType,
+    ClassificationStatus,
+    PendingQuestionType,
+)
 from adv_assistant.db.models import AdDraft, AuditEvent, ConversationSession, Operator
-from adv_assistant.db.repositories import OperatorRepository
+from adv_assistant.db.repositories import (
+    AdDraftRepository,
+    ConversationSessionRepository,
+    OperatorRepository,
+)
 from adv_assistant.db.session import create_engine, create_session_factory, session_scope
 from adv_assistant.enrichment import EnrichedProduct
 from adv_assistant.llm_gateway import (
@@ -336,9 +346,13 @@ async def test_pipeline_processes_image_message_and_updates_draft(
     )
 
     assert result.status == "processed"
-    assert result.deterministic_action == "operator_photo_ingest"
+    assert result.deterministic_action == "product_confirmation_requested"
+    assert result.generated_image_url == (
+        "https://storage.googleapis.com/test-media/operator-photos/p1.jpg"
+    )
     assert result.reply_text is not None
-    assert "7290004127326" in result.reply_text
+    assert "זה המוצר שהתכוונת אליו" in result.reply_text
+    assert result.action_buttons is not None
 
     async with session_scope(session_factory) as session:
         session_obj = (
@@ -351,6 +365,11 @@ async def test_pipeline_processes_image_message_and_updates_draft(
         assert draft.photo_url == "https://storage.googleapis.com/test-media/operator-photos/p1.jpg"
         assert draft.ean == "7290004127326"
         assert draft.product_name == "קוטג תנובה"
+        assert draft.request_type == AdRequestType.SINGLE_PRODUCT
+        assert draft.classification_status == ClassificationStatus.RESOLVED
+        assert draft.is_classification_resolved is True
+        assert draft.awaiting_product_confirmation is True
+        assert session_obj.pending_question_type == PendingQuestionType.PRODUCT_CONFIRMATION
 
         audit_rows = (
             await session.execute(
@@ -358,6 +377,80 @@ async def test_pipeline_processes_image_message_and_updates_draft(
             )
         ).scalars()
         assert len(list(audit_rows)) == 1
+
+
+async def test_pipeline_image_message_starts_confirmation_when_existing_draft_has_no_photo(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    phone = "+972500000611"
+    await _seed_operator(session_factory, phone)
+
+    async with session_scope(session_factory) as session:
+        draft_repo = AdDraftRepository(session)
+        session_repo = ConversationSessionRepository(session)
+        draft = await draft_repo.create(
+            operator_phone=phone,
+            status=AdDraftStatus.DRAFT,
+            currency="ILS",
+            request_type=AdRequestType.SINGLE_PRODUCT,
+            classification_status=ClassificationStatus.RESOLVED,
+            is_classification_resolved=True,
+            awaiting_product_confirmation=False,
+            product_name="מוצר קודם",
+            photo_url=None,
+            rendered_image_url=None,
+            preview_reference_url=None,
+        )
+        await session_repo.create_or_update(
+            operator_phone=phone,
+            history=[],
+            current_draft_id=draft.id,
+            pending_question_type=PendingQuestionType.NONE,
+            pending_question_context={},
+        )
+
+    processor = InboundTaskProcessor(
+        session_factory,
+        operator_photo_ingestor=StaticPhotoIngestor(
+            IngestedOperatorPhoto(
+                public_url="https://storage.googleapis.com/test-media/operator-photos/p2.jpg",
+                object_name="operator-photos/p2.jpg",
+                content_type="image/jpeg",
+                content=b"jpeg-bytes",
+            )
+        ),
+        enrichment_service=StaticEnrichmentService(decoded_ean=None, enriched=None),
+    )
+
+    result = await processor.process(
+        InboundTaskPayload(
+            wamid="wamid-phase6-image-2",
+            operator_phone=phone,
+            raw_message={"type": "image", "image": {"id": "meta-media-2"}},
+        )
+    )
+
+    assert result.status == "processed"
+    assert result.deterministic_action == "product_confirmation_requested"
+    assert result.generated_image_url == (
+        "https://storage.googleapis.com/test-media/operator-photos/p2.jpg"
+    )
+    assert result.action_buttons is not None
+
+    async with session_scope(session_factory) as session:
+        session_obj = (
+            await session.execute(
+                select(ConversationSession).where(ConversationSession.operator_phone == phone)
+            )
+        ).scalar_one()
+        draft = await session.get(AdDraft, session_obj.current_draft_id)
+        assert draft is not None
+        assert draft.request_type == AdRequestType.SINGLE_PRODUCT
+        assert draft.classification_status == ClassificationStatus.RESOLVED
+        assert draft.is_classification_resolved is True
+        assert draft.awaiting_product_confirmation is True
+        assert draft.photo_url == "https://storage.googleapis.com/test-media/operator-photos/p2.jpg"
+        assert session_obj.pending_question_type == PendingQuestionType.PRODUCT_CONFIRMATION
 
 
 async def test_pipeline_image_ingest_failure_is_user_visible(
@@ -382,6 +475,8 @@ async def test_pipeline_image_ingest_failure_is_user_visible(
     assert result.status == "processed"
     assert result.reply_text is not None
     assert "could not process your photo" in result.reply_text.lower()
+    assert result.generated_image_url is None
+    assert result.action_buttons is None
 
 
 async def test_pipeline_set_logo_routes_next_image_to_operator_logo(

--- a/tests/test_phase8_cms_publish.py
+++ b/tests/test_phase8_cms_publish.py
@@ -156,6 +156,16 @@ async def test_confirm_publish_button_publishes_to_cms_and_marks_draft_published
         assert published_row is not None
         assert published_row.cms_id == "975"
 
+        session_obj = await ConversationSessionRepository(session).get_by_operator_phone(phone)
+        assert session_obj is not None
+        assert session_obj.current_draft_id is not None
+        assert session_obj.current_draft_id != draft_id
+        active_draft = await session.get(AdDraft, session_obj.current_draft_id)
+        assert active_draft is not None
+        assert active_draft.status == AdDraftStatus.DRAFT
+        assert active_draft.product_name is None
+        assert active_draft.rendered_image_url is None
+
 
 async def test_confirm_publish_button_returns_error_message_when_cms_fails(
     session_factory: async_sessionmaker[AsyncSession],
@@ -301,7 +311,7 @@ async def test_confirm_publish_routes_by_operator_cms_mapping(
     assert cms.target_calls == [(157, 139), (501, 808)]
 
 
-async def test_re_pressing_publish_on_already_published_draft_is_idempotent(
+async def test_re_pressing_publish_after_reset_is_blocked_without_new_preview(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     phone = "+972500000806"
@@ -326,7 +336,7 @@ async def test_re_pressing_publish_on_already_published_draft_is_idempotent(
     assert first.status == "processed"
     assert cms.calls == 1
 
-    # Re-press publish on the same (now PUBLISHED) draft.
+    # Re-press publish after the flow already reset to a fresh draft.
     second_payload = InboundTaskPayload(
         wamid="wamid-phase8-idem-2",
         operator_phone=phone,
@@ -337,8 +347,10 @@ async def test_re_pressing_publish_on_already_published_draft_is_idempotent(
     )
     second = await processor.process(second_payload)
     assert second.status == "processed"
+    assert second.reply_text is not None
     assert (
-        "כבר פורסמה" in second.reply_text or "already been published" in second.reply_text.lower()
+        "אין כרגע תמונת תצוגה מוכנה לפרסום" in second.reply_text
+        or "no generated preview image ready for publishing" in second.reply_text.lower()
     )
     assert cms.calls == 1  # no additional CMS call
 

--- a/tests/test_stage2_system_memory.py
+++ b/tests/test_stage2_system_memory.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from pathlib import Path
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from adv_assistant import creative_brief_planner
@@ -16,9 +17,16 @@ from adv_assistant.ad_generation import (
     build_generation_prompt,
 )
 from adv_assistant.db.base import Base
-from adv_assistant.db.repositories import ConversationSessionRepository, OperatorRepository
+from adv_assistant.db.enums import AdDraftStatus
+from adv_assistant.db.models import AdDraft
+from adv_assistant.db.repositories import (
+    AdDraftRepository,
+    ConversationSessionRepository,
+    OperatorRepository,
+)
 from adv_assistant.db.session import create_engine, create_session_factory, session_scope
 from adv_assistant.llm_gateway import (
+    BUTTON_CANCEL_PUBLISH,
     ExtractedAdFields,
     ExtractedBrandingFields,
     ExtractedProductQuery,
@@ -377,19 +385,17 @@ async def test_generation_adds_followup_when_system_memory_is_missing(
     assert result.publish_buttons_prompt is None  # deferred until after variant selection
 
 
-async def test_followup_questions_are_asked_one_by_one_then_regenerate_confirmation(
+async def test_variant_selection_shows_publish_and_feedback_regenerates_current_draft(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     phone = "+972500000714"
     await _seed_operator(session_factory, phone)
 
     gateway = SequencedGateway(
-        intents=[Intent.CREATE_AD, Intent.UNKNOWN, Intent.UNKNOWN],
+        intents=[Intent.CREATE_AD, Intent.CREATE_AD],
         ad_fields=[
             ExtractedAdFields(product_name="קולה", price=Decimal("6.00"), currency="ILS"),
-            ExtractedAdFields(price=Decimal("7.90"), currency="ILS"),
         ],
-        branding_fields=[ExtractedBrandingFields()],
     )
     generation = FakeGenerationService()
     processor = InboundTaskProcessor(
@@ -409,7 +415,7 @@ async def test_followup_questions_are_asked_one_by_one_then_regenerate_confirmat
     assert first.action_buttons is not None  # variant selection buttons shown
     assert len(generation.submitted_drafts) == 2  # two variant slots per generation
 
-    # Select variant A to proceed to follow-up questions.
+    # Select variant A and move directly to publish buttons.
     variant_select = await processor.process(
         InboundTaskPayload(
             wamid="wamid-stage2-seq-1b",
@@ -421,51 +427,24 @@ async def test_followup_questions_are_asked_one_by_one_then_regenerate_confirmat
         )
     )
     assert variant_select.reply_text is not None
-    assert "מה סוג העסק שלך" in variant_select.reply_text
+    assert "גרסה A נבחרה" in variant_select.reply_text
     assert variant_select.publish_buttons_prompt is not None
+    assert "תרצה לפרסם את הגרסא שבחרת" in variant_select.publish_buttons_prompt
     assert len(generation.submitted_drafts) == 2
 
+    # Free-text feedback should regenerate the same draft.
     second = await processor.process(
         InboundTaskPayload(
             wamid="wamid-stage2-seq-2",
             operator_phone=phone,
-            raw_message={"type": "text", "text": {"body": "סופרמרקט שכונתי"}},
+            raw_message={"type": "text", "text": {"body": "תגדיל את הלוגו ותבליט את המחיר"}},
         )
     )
     assert second.reply_text is not None
-    assert "הנחיות כלליות לסגנון המודעות" in second.reply_text
-    assert len(generation.submitted_drafts) == 2  # no new generation
-
-    third = await processor.process(
-        InboundTaskPayload(
-            wamid="wamid-stage2-seq-3",
-            operator_phone=phone,
-            raw_message={"type": "text", "text": {"body": "סגנון נקי עם צבעים כחולים"}},
-        )
-    )
-    assert third.reply_text is not None
-    assert "רוצה שאפעיל עכשיו יצירת מודעה נוספת" in third.reply_text
-    assert len(generation.submitted_drafts) == 2  # still no new generation
-
-    fourth = await processor.process(
-        InboundTaskPayload(
-            wamid="wamid-stage2-seq-4",
-            operator_phone=phone,
-            raw_message={"type": "text", "text": {"body": "כן מחיר 7.90"}},
-        )
-    )
-    assert fourth.reply_text is not None
-    assert "התצוגה המקדימה מוכנה" in fourth.reply_text
-    assert "רוצה שאפעיל עכשיו יצירת מודעה נוספת" not in fourth.reply_text
+    assert "התצוגה המקדימה מוכנה" in second.reply_text
     assert len(generation.submitted_drafts) == 4  # 2 generations × 2 variant slots
-    assert generation.submitted_drafts[2].price == Decimal("7.90")
 
     async with session_scope(session_factory) as session:
-        operator = await OperatorRepository(session).get_by_phone(phone)
-        assert operator is not None
-        assert operator.store_type == "סופרמרקט שכונתי"
-        assert operator.creative_guidance == "סגנון נקי עם צבעים כחולים"
-
         session_obj = await ConversationSessionRepository(session).get_by_operator_phone(phone)
         assert session_obj is not None
         assert session_obj.pending_followup_question is None
@@ -514,7 +493,7 @@ async def test_followup_interrupt_create_ad_skips_pending_question_and_generates
     assert generation.submitted_drafts[2].product_name == "חלב"
 
 
-async def test_regenerate_confirmation_unclear_answer_keeps_pending_state(
+async def test_variant_selection_uses_new_publish_question_text(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     phone = "+972500000716"
@@ -558,23 +537,14 @@ async def test_regenerate_confirmation_unclear_answer_keeps_pending_state(
         )
     )
     assert variant_select.reply_text is not None
-    assert "רוצה שאפעיל עכשיו יצירת מודעה נוספת" in variant_select.reply_text
-
-    second = await processor.process(
-        InboundTaskPayload(
-            wamid="wamid-stage2-unclear-2",
-            operator_phone=phone,
-            raw_message={"type": "text", "text": {"body": "אולי"}},
-        )
-    )
-    assert second.reply_text is not None
-    assert "רוצה שאפעיל עכשיו יצירת מודעה נוספת" in second.reply_text
-    assert len(generation.submitted_drafts) == 2  # two variant slots per generation
+    assert "גרסה A נבחרה" in variant_select.reply_text
+    assert variant_select.publish_buttons_prompt is not None
+    assert "תרצה לפרסם את הגרסא שבחרת" in variant_select.publish_buttons_prompt
 
     async with session_scope(session_factory) as session:
         session_obj = await ConversationSessionRepository(session).get_by_operator_phone(phone)
         assert session_obj is not None
-        assert session_obj.pending_followup_question == "regenerate_confirmation"
+        assert session_obj.pending_followup_question is None
 
 
 async def test_publish_buttons_sent_even_when_followup_pending(
@@ -608,7 +578,7 @@ async def test_publish_buttons_sent_even_when_followup_pending(
     assert result.action_buttons is not None
 
 
-async def test_regenerate_confirmation_decline_returns_publish_buttons(
+async def test_cancel_publish_resets_current_draft(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
     phone = "+972500000719"
@@ -646,7 +616,7 @@ async def test_regenerate_confirmation_decline_returns_publish_buttons(
     assert first.reply_text is not None
     assert first.action_buttons is not None  # variant selection buttons shown
 
-    # Select variant A to proceed to regenerate confirmation.
+    # Select variant A to expose publish buttons.
     variant_select = await processor.process(
         InboundTaskPayload(
             wamid="wamid-stage2-decline-1b",
@@ -658,19 +628,39 @@ async def test_regenerate_confirmation_decline_returns_publish_buttons(
         )
     )
     assert variant_select.reply_text is not None
-    assert "רוצה שאפעיל עכשיו יצירת מודעה נוספת" in variant_select.reply_text
+    assert "גרסה A נבחרה" in variant_select.reply_text
     assert variant_select.publish_buttons_prompt is not None
 
     second = await processor.process(
         InboundTaskPayload(
             wamid="wamid-stage2-decline-2",
             operator_phone=phone,
-            raw_message={"type": "text", "text": {"body": "לא"}},
+            raw_message={
+                "type": "interactive",
+                "interactive": {"button_reply": {"id": BUTTON_CANCEL_PUBLISH}},
+            },
         )
     )
+    assert second.deterministic_action == "cancel_publish"
     assert second.reply_text is not None
-    assert "כשתרצה ליצור מודעה נוספת" in second.reply_text
-    assert second.publish_buttons_prompt is not None
+    assert "המודעה לא פורסמה" in second.reply_text
+
+    async with session_scope(session_factory) as session:
+        drafts = (
+            (await session.execute(select(AdDraft).where(AdDraft.operator_phone == phone)))
+            .scalars()
+            .all()
+        )
+        assert len(drafts) == 2
+
+        session_obj = await ConversationSessionRepository(session).get_by_operator_phone(phone)
+        assert session_obj is not None
+        assert session_obj.current_draft_id is not None
+        active_draft = await AdDraftRepository(session).get_by_id(session_obj.current_draft_id)
+        assert active_draft is not None
+        assert active_draft.status == AdDraftStatus.DRAFT
+        assert active_draft.product_name is None
+        assert active_draft.rendered_image_url is None
 
 
 async def test_clear_request_removes_operator_fields_and_clears_pending_followup(


### PR DESCRIPTION
## Summary
- add image-first product intake path: first product image now moves directly to product confirmation (image + confirm/reject buttons)
- keep `SET_LOGO` priority and preserve regular image-ingest behavior for non-image-first states
- consolidate product-confirmation response building into a shared helper used by both text and image-first paths
- remove the legacy "generate another ad now?" follow-up from the main flow
- after variant selection, show publish buttons directly; free-text feedback regenerates on the same draft unless the user explicitly asks for a new ad
- update publish prompt text to:
  - "תרצה לפרסם את הגרסא שבחרת?"
  - "(במידה ויש שינויים נוספים תכתוב אותם כאן)"
- on `Apply` / `Cancel`, reset active draft context for next flow
- prevent follow-up regenerate feedback from mutating operator branding memory

## Tests
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`

All checks pass locally.
